### PR TITLE
Added resizing of constraint optimizer's solve input

### DIFF
--- a/cisstNumerical/code/nmrConstraintOptimizer.cpp
+++ b/cisstNumerical/code/nmrConstraintOptimizer.cpp
@@ -50,10 +50,13 @@ nmrConstraintOptimizer::STATUS nmrConstraintOptimizer::Solve(vctDoubleVec &dq)
 {
     CISSTNETLIB_INTEGER res;
 
+    // make sure input is the correct size
+    dq.SetSize(NumVars+Slacks);
+
     // if we don't see an objective
     if (C.rows() == 0 || d.size() == 0) {
         dq.SetAll(0);
-        return NMR_MALFORMED;
+        return NMR_EMPTY;
     }
 
     // if the sizes don't match for C,d

--- a/cisstNumerical/nmrConstraintOptimizer.h
+++ b/cisstNumerical/nmrConstraintOptimizer.h
@@ -42,7 +42,7 @@ public:
     //! 2  Inequality constraints are contradictory.
     //! 3  Both equality and inequality constraints are contradictory.
     //! 4  Input has a NaN or INF
-    enum STATUS {NMR_OK, NMR_EQ_CONTRADICTION, NMR_INEQ_CONTRADICTION, NMR_BOTH_CONTRADICTION, NMR_MALFORMED};
+    enum STATUS {NMR_OK, NMR_EQ_CONTRADICTION, NMR_INEQ_CONTRADICTION, NMR_BOTH_CONTRADICTION, NMR_MALFORMED, NMR_EMPTY};
 
     //!Objective Matrix
     vctDoubleMat C;


### PR DESCRIPTION
Before the user was expected to resize the output vector before calling solve, now the constraint optimizer does it automatically. I also added a new error type for an empty objective, which is needed.
