### PR TITLE
use __linux__ macro to check whether OS is Linux

### DIFF
--- a/cisstCommon/cmnPortability.h
+++ b/cisstCommon/cmnPortability.h
@@ -104,7 +104,7 @@ http://www.cisst.org/cisst/license.txt.
 // (Another compiler may determine the OS differently).
 #ifdef __GNUC__  // see man gcc
   #define CISST_COMPILER CISST_GCC
-  #ifdef linux // see cpp -dM and ctrl+d
+  #if (defined(linux) || defined(__linux__)) // see cpp -dM and ctrl+d
     #define CISST_OS CISST_LINUX
   #endif // linux
   #if CISST_HAS_LINUX_RTAI // overwrite if RTAI


### PR DESCRIPTION
I think one more macro should be used to check whether OS is Linux. I tested this commit and catkin build succeeded on Unbuntu 16.04 with gcc 5.4.0
references: 
1. https://code.woboq.org/qt5/qtbase/src/corelib/global/qconfig-bootstrapped.h.html#90
2. https://code.woboq.org/qt5/include/SDL2/SDL_platform.h.html#59