### PR TITLE
make neccessary changes to build cisst and other saw components with C++ 14 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,13 +292,20 @@ check_size_t_native_type (CISST_SIZE_T_NATIVE)
 
 # Determine if we can use cast to void * for CMN_LOG
 include (CheckCXXSourceCompiles)
-check_cxx_source_compiles(
-"#include <iostream>
-int main(int argc, char ** argv) {
-    true ? (void *) 0 : std::cerr << \"true\";
-    false ? (void *) 0 : std::cerr << \"false\";
-    return 0;
-}" CISST_OSTREAM_CAN_CAST_TO_VOID_PTR)
+if( ("${CMAKE_CXX_STANDARD}" STREQUAL "14") OR ("${CMAKE_CXX_STANDARD}" STREQUAL "17"))
+    set(CISST_OSTREAM_CAN_CAST_TO_VOID_PTR 0)
+    set(CISST_USE_STD_ISNAN 1)
+    set(CISST_USE_STD_ISFINITE 1)
+    set(CISST_USE_CMATH 1)
+else()
+    check_cxx_source_compiles(
+    "#include <iostream>
+    int main(int argc, char ** argv) {
+        true ? (void *) 0 : std::cerr << \"true\";
+        false ? (void *) 0 : std::cerr << \"false\";
+        return 0;
+    }" CISST_OSTREAM_CAN_CAST_TO_VOID_PTR)
+endif()
 
 check_cxx_source_compiles(
 "#include <iostream>

--- a/cisstCommon/cmnPortability.h
+++ b/cisstCommon/cmnPortability.h
@@ -343,9 +343,11 @@ extern CISST_EXPORT const std::string cmnCompilersStrings[];
 #endif // DOXYGEN
 
 
-
+#ifndef CISST_USE_CMATH
 #include <math.h>
-
+#else
+#include <cmath>
+#endif
 /*!  Discard of the Windows.h definition of macros min and max
 */
 #if CISST_OS_IS_WINDOWS
@@ -389,7 +391,11 @@ extern CISST_EXPORT const std::string cmnCompilersStrings[];
       extern "C" int isnan (double);
     #endif
   #endif
-  #define CMN_ISNAN(x) isnan(x)
+  #ifndef CISST_USE_STD_ISNAN
+    #define CMN_ISNAN(x) isnan(x)
+  #else
+    #define CMN_ISNAN(x) std::isnan(x)
+  #endif
 #endif
 
 

--- a/cisstCommon/code/cmnPortability.cpp
+++ b/cisstCommon/code/cmnPortability.cpp
@@ -56,7 +56,11 @@ const std::string cmnCompilersStrings[] = {"Undefined",
 bool cmnIsFinite(const float & value)
 {
 #if CISST_HAS_ISFINITE
-    return isfinite(value);
+    #ifndef CISST_USE_STD_ISFINITE
+        return isfinite(value);
+    #else
+        return std::isfinite(value);
+    #endif
 #else
 #ifdef CISST_COMPILER_IS_MSVC
     return _finite(value) == 1;
@@ -71,7 +75,11 @@ bool cmnIsFinite(const float & value)
 bool cmnIsFinite(const double & value)
 {
 #if CISST_HAS_ISFINITE
-    return isfinite(value);
+    #ifndef CISST_USE_STD_ISFINITE
+        return isfinite(value);
+    #else
+        return std::isfinite(value);
+    #endif
 #else
 #ifdef CISST_COMPILER_IS_MSVC
     return _finite(value) == 1;

--- a/cisstConfig.h.in
+++ b/cisstConfig.h.in
@@ -91,4 +91,10 @@ http://www.cisst.org/cisst/license.txt.
 // Using SI units (ie meters) or mm for distances
 #cmakedefine01 CISST_USE_SI_UNITS
 
+// include <cmath> header file instead of <math.h>
+#cmakedefine CISST_USE_CMATH
+// Using std::isnan
+#cmakedefine CISST_USE_STD_ISNAN
+// Using std::isfinite
+#cmakedefine CISST_USE_STD_ISFINITE
 #endif // _cisstConfig_h


### PR DESCRIPTION
Without this patch, dvrk_console_json cannot be built with C++ 14 standard. This patch

1. include <cmath> instead of <math.h>
2. use std::isnan instead of isnan
3. use std::isfinite instead of isfinite
4. set CISST_OSTREAM_CAN_CAST_TO_VOID_PTR  to 0

if CMAKE_CXX_STANDARD is set to 14 or 17. Please read https://groups.google.com/forum/#!topic/research-kit-for-davinci/E24PRPDaFKU