### PR TITLE
Enable alternate filename (including path) for cisstLog.txt

### DIFF
--- a/cisstCommon/cmnLogger.h
+++ b/cisstCommon/cmnLogger.h
@@ -5,7 +5,7 @@
   Author(s):  Anton Deguet
   Created on: 2004-08-31
 
-  (C) Copyright 2004-2016 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2004-2018 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -276,6 +276,13 @@ class CISST_EXPORT cmnLogger {
     /*! Single multiplexer used to stream the log out */
     StreamBufType LoDMultiplexerStreambuf;
 
+    /*! Default filename (possibly including path) for default log.
+        Normally, cisstLog.txt in current directory. */
+    static std::string DefaultLogFileName;
+
+    /*! Whether cmnLogger instance has been created. */
+    static bool InstanceCreated;
+
     /*! Instance specific implementation of SetMask.
       \sa SetMask */
     void SetMaskInstance(cmnLogMask mask);
@@ -297,7 +304,7 @@ class CISST_EXPORT cmnLogger {
     StreamBufType * GetMultiplexerInstance(void);
 
     /*! Create and get a pointer on the default log file. */
-    std::ofstream * DefaultLogFile(const std::string & defaultLogFileName = "cisstLog.txt");
+    std::ofstream * DefaultLogFile(const std::string & defaultLogFileName = DefaultLogFileName);
 
     /*! Instance specific implementation of HaltDefaultLog. */
     void HaltDefaultLogInstance(void);
@@ -317,7 +324,7 @@ class CISST_EXPORT cmnLogger {
  protected:
     /*! Constructor.  The only constructor must be private in order to
       ensure that the class register is a singleton. */
-    cmnLogger(const std::string & defaultLogFileName = "cisstLog.txt");
+    cmnLogger(const std::string & defaultLogFileName = DefaultLogFileName);
 
  public:
     /*! The log is instantiated as a singleton.  To access the unique
@@ -475,6 +482,16 @@ class CISST_EXPORT cmnLogger {
         Instance()->KillInstance();
     }
 
+    /*! Set the name of the default log file. This function must be called before the cmnLogger instance is created.
+        \returns true if the default log file name can be set (i.e., cmnLogger instance not yet created); false otherwise.
+    */
+    static bool SetDefaultLogFileName(const std::string &defaultLogFileName);
+
+    /*! Returns name of default log file. */
+    static std::string GetDefaultLogFileName(void) { return DefaultLogFileName; }
+
+    /*! Returns true if cmnLogger instance has been created (i.e., constructor called). */
+    static bool IsCreated() { return InstanceCreated; }
 };
 
 

--- a/cisstCommon/code/cmnClassRegister.cpp
+++ b/cisstCommon/code/cmnClassRegister.cpp
@@ -6,8 +6,7 @@
   Author(s):  Alvin Liem, Anton Deguet
   Created on: 2002-08-01
 
-  (C) Copyright 2002-2010 Johns Hopkins University (JHU), All Rights
-  Reserved.
+  (C) Copyright 2002-2018 Johns Hopkins University (JHU), All Rights Reserved.
 
   --- begin cisst license - do not edit ---
 
@@ -24,7 +23,6 @@
 
 #include <cisstCommon/cmnClassRegister.h>
 #include <cisstCommon/cmnClassServices.h>
-
 
 cmnClassRegister* cmnClassRegister::Instance(void) {
     // create a static variable
@@ -47,8 +45,10 @@ const std::string * cmnClassRegister::RegisterInstance(cmnClassServicesBase* cla
         EntryType newEntry(className, classServicesPointer);
         insertionResult = ServicesContainer.insert(newEntry);
         if (insertionResult.second) {
-            CMN_LOG_INIT_VERBOSE << "Class cmnClassRegister: Register: class \"" << className
-                                 << "\" has been registered with Log LoD \"" << cmnLogMaskToString(classServicesPointer->GetLoD()) << "\"" << std::endl;
+            if (cmnLogger::IsCreated()) {
+                CMN_LOG_INIT_VERBOSE << "Class cmnClassRegister: Register: class \"" << className
+                                     << "\" has been registered with Log LoD \"" << cmnLogMaskToString(classServicesPointer->GetLoD()) << "\"" << std::endl;
+            }
             return &((*insertionResult.first).first);
         } else {
             CMN_LOG_INIT_ERROR << "Class cmnClassRegister: Register: class \"" << className
@@ -150,11 +150,6 @@ cmnClassServicesBase * cmnClassRegister::FindClassServicesInstance(const std::st
     iterator = ServicesContainer.find(className);
     if (iterator != end) {
         result = iterator->second;
-        CMN_LOG_RUN_DEBUG << "Class cmnClassRegister: FindClassServices: found class info for \""
-                          << className << "\"" << std::endl;
-    } else {
-        CMN_LOG_RUN_VERBOSE << "Class cmnClassRegister: FindClassServices: couldn't find class info for \""
-                            << className << "\"" << std::endl;
     }
     return result;
 }
@@ -169,8 +164,6 @@ cmnClassServicesBase * cmnClassRegister::FindClassServicesInstance(const std::ty
     while ((iterator != end) && (result == NULL)) {
         if (*((iterator->second)->TypeInfoPointer()) == typeInfo) {
             result = iterator->second;
-            CMN_LOG_RUN_VERBOSE << "Class cmnClassRegister: FindClassServicesInstance: found class info for the given type_info"
-                                << std::endl;
         }
         iterator++;
     }

--- a/cisstCommon/code/cmnLogger.cpp
+++ b/cisstCommon/code/cmnLogger.cpp
@@ -5,7 +5,7 @@
   Author(s):  Anton Deguet
   Created on: 2004-08-31
 
-  (C) Copyright 2004-2015 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2004-2018 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -30,11 +30,28 @@ http://www.cisst.org/cisst/license.txt.
 #include <cisstCommon/cmnPath.h>
 #include <cisstCommon/cmnUnits.h>
 
+// Whether cmnLogger instance has been created. Since this is a built-in type,
+// it should be initialized early.
+bool cmnLogger::InstanceCreated = false;
+
+// Default log file name is "cisstLog.txt" (in current directory)
+std::string cmnLogger::DefaultLogFileName("cisstLog.txt");
+
+bool cmnLogger::SetDefaultLogFileName(const std::string & defaultLogFileName)
+{
+    if (!IsCreated()) {
+        DefaultLogFileName = defaultLogFileName;
+        return true;
+    }
+    return false;
+}
+
 cmnLogger::cmnLogger(const std::string & defaultLogFileName):
     Mask(CMN_LOG_ALLOW_ALL),
     FunctionMask(CMN_LOG_ALLOW_ERRORS),
     LoDMultiplexerStreambuf()
 {
+    cmnLogger::InstanceCreated = true;
     LoDMultiplexerStreambuf.AddChannel(*(DefaultLogFile(defaultLogFileName)), CMN_LOG_ALLOW_DEFAULT);
     *(DefaultLogFile()) << cmnLogLevelToString(CMN_LOG_LEVEL_INIT_VERBOSE) << " " << CISST_FULL_REVISION << std::endl;
     std::string result = "undefined";


### PR DESCRIPTION
Added `cmnLogger:SetDefaultLogFileName` to allow programmer to specify alternate filename (instead of `cisstLog.txt`). This can only be done before the log file is created, which can be queried by the new method `cmnLogger::IsCreated`.  Removed some logger calls in `cmnClassRegister` (or gated them based on `cmnLogger::IsCreated`) to reduce chance that logger is created before program main is started.

User code can now do the following (e.g., where `full_path` is the desired path for the default log file):
```
if (!cmnLogger::SetDefaultLogFileName(full_path)) {
    // SetDefaultLogFileName returns false if cisstLog.txt has already been created
    // in the current directory. In this case, we halt he default log and instead
    // create another channel.
    cmnLogger::HaltDefaultLog();
    static std::ofstream altlog(full_path);
    cmnLogger::AddChannel(altlog, CMN_LOG_ALLOW_VERBOSE);
}
```


