### PR TITLE
Minor fixes

### DIFF
--- a/cisstCommon/tests/cmnLoggerTest.cpp
+++ b/cisstCommon/tests/cmnLoggerTest.cpp
@@ -28,16 +28,16 @@ void cmnLoggerTest::TestLoggerFileName(void)
     // Depending on order that tests are run, logger may already be created. This means that we
     // have to trust that cmnLogger::IsCreated is working. To run "Case 2" (logger not yet created),
     // try running just a single test
-    CPPUNIT_ASSERT_EQUAL(std::string("cisstLog.txt"), cmnLogger::GetDefaultLogFileName());
     if (cmnLogger::IsCreated()) {
         std::cout << std::endl << "TestLoggerFileName: Case 1: log file created before test" << std::endl;
+        CPPUNIT_ASSERT_EQUAL(std::string("testLog.txt"), cmnLogger::GetDefaultLogFileName());
         CPPUNIT_ASSERT_EQUAL(false, cmnLogger::SetDefaultLogFileName("testLog.txt"));
-        CPPUNIT_ASSERT_EQUAL(std::string("cisstLog.txt"), cmnLogger::GetDefaultLogFileName());
     }
     else {
         std::cout << std::endl << "TestLoggerFileName: Case 2: log file not created before test" << std::endl;
         if (cmnPath::Exists("testLog.txt"))
             std::cout << "  testLog.txt already exists -- please delete and run test again" << std::endl;
+        CPPUNIT_ASSERT_EQUAL(std::string("cisstLog.txt"), cmnLogger::GetDefaultLogFileName());
         CPPUNIT_ASSERT_EQUAL(true, cmnLogger::SetDefaultLogFileName("testLog.txt"));
         CPPUNIT_ASSERT_EQUAL(std::string("testLog.txt"), cmnLogger::GetDefaultLogFileName());
         // Following call will create log file

--- a/cisstMultiTask/code/mtsTask.cpp
+++ b/cisstMultiTask/code/mtsTask.cpp
@@ -157,6 +157,8 @@ void mtsTask::StartupInternal(void) {
         CMN_LOG_CLASS_INIT_ERROR << "StartupInternal: task \"" << this->GetName() << "\" cannot be started." << std::endl;
     }
     CMN_LOG_CLASS_INIT_VERBOSE << "StartupInternal: ended for task \"" << this->GetName() << "\"" << std::endl;
+    // advance all state tables (if automatic)
+    StateTables.ForEachVoid(&mtsStateTable::AdvanceIfAutomatic);
     RunEvent();
 }
 


### PR DESCRIPTION
See the two commit comments for details.

First commit is an obvious test-only-code change so the test will pass.

Second commit is an AdvanceIfAutomatic call at the end of Startup. We've been using it since last summer -- it fixes incorrect data being returned from a component which has been started up, but which has not yet completed its first Run method call.
