### PR TITLE
Enable sequential multiple mtsManagerLocal instances

### DIFF
--- a/cisstMultiTask/code/mtsManagerLocal.cpp
+++ b/cisstMultiTask/code/mtsManagerLocal.cpp
@@ -319,6 +319,9 @@ void mtsManagerLocal::Cleanup(void)
         SystemLogMultiplexer = 0;
     }
 
+    delete Instance;
+    Instance = 0;
+
     __os_exit();
 }
 

--- a/cisstMultiTask/tests/mtsManagerLocalTest.cpp
+++ b/cisstMultiTask/tests/mtsManagerLocalTest.cpp
@@ -65,43 +65,45 @@ void mtsManagerLocalTest::TestInitialize(void)
 
 void mtsManagerLocalTest::TestConstructor(void)
 {
-    mtsManagerLocal localManager;
-    CPPUNIT_ASSERT_EQUAL(localManager.ProcessName, string(DEFAULT_PROCESS_NAME));
-    CPPUNIT_ASSERT(localManager.ManagerGlobal);
+    mtsManagerLocal * localManager = mtsManagerLocal::GetInstance();
+    localManager->RemoveAllUserComponents();  // Clean up from previous tests
 
-    mtsManagerGlobal * GCM = dynamic_cast<mtsManagerGlobal*>(localManager.ManagerGlobal);
+    CPPUNIT_ASSERT_EQUAL(localManager->ProcessName, string(DEFAULT_PROCESS_NAME));
+    CPPUNIT_ASSERT(localManager->ManagerGlobal);
+
+    mtsManagerGlobal * GCM = dynamic_cast<mtsManagerGlobal*>(localManager->ManagerGlobal);
     CPPUNIT_ASSERT(GCM);
 
-    CPPUNIT_ASSERT(GCM->FindProcess(localManager.ProcessName));
-    CPPUNIT_ASSERT(GCM->GetProcessObject(localManager.ProcessName) == &localManager);
+    CPPUNIT_ASSERT(GCM->FindProcess(localManager->ProcessName));
+    CPPUNIT_ASSERT(GCM->GetProcessObject(localManager->ProcessName) == localManager);
 }
 
 void mtsManagerLocalTest::TestCleanup(void)
 {
-    mtsManagerLocal managerLocal;
+    mtsManagerLocal * localManager = mtsManagerLocal::GetInstance();
+    localManager->RemoveAllUserComponents();  // Clean up from previous tests
 
-    CPPUNIT_ASSERT(managerLocal.ManagerGlobal);
+    CPPUNIT_ASSERT(localManager->ManagerGlobal);
     mtsTestDevice1<mtsInt> * dummy = new mtsTestDevice1<mtsInt>;
-    CPPUNIT_ASSERT(managerLocal.ComponentMap.AddItem("dummy", dummy));
-    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), managerLocal.ComponentMap.size());
+    CPPUNIT_ASSERT(localManager->ComponentMap.AddItem("dummy", dummy));
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(3), localManager->ComponentMap.size());
 
-    managerLocal.Cleanup();
-
-    CPPUNIT_ASSERT(managerLocal.ManagerGlobal == 0);
-    // Changed to 1 because size()==1, Cleanup does not remove items from ComponentMap...
-    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), managerLocal.ComponentMap.size());
+    localManager->Cleanup();
+    localManager = nullptr;
+      // Cleanup now deletes the singleton (which is == localManager here),
+      // cannot reference localManager after the Cleanup call.
 
     // Add __os_exit() test if needed.
 }
 
 void mtsManagerLocalTest::TestGetInstance(void)
 {
-    mtsManagerLocal * managerLocal = mtsManagerLocal::GetInstance();
+    mtsManagerLocal * localManager = mtsManagerLocal::GetInstance();
 
-    CPPUNIT_ASSERT(managerLocal);
-    CPPUNIT_ASSERT(managerLocal->ManagerGlobal);
-    CPPUNIT_ASSERT_EQUAL(managerLocal, mtsManagerLocal::Instance);
-    CPPUNIT_ASSERT(managerLocal->ManagerGlobal->FindProcess(DEFAULT_PROCESS_NAME));
+    CPPUNIT_ASSERT(localManager);
+    CPPUNIT_ASSERT(localManager->ManagerGlobal);
+    CPPUNIT_ASSERT_EQUAL(localManager, mtsManagerLocal::Instance);
+    CPPUNIT_ASSERT(localManager->ManagerGlobal->FindProcess(DEFAULT_PROCESS_NAME));
 }
 
 void mtsManagerLocalTest::TestAddComponent(void)


### PR DESCRIPTION
Commit comments explain.

We have found that using "delete Instance" in the Cleanup method has allowed us to write tests of our own components where each test follows the pattern:
```
GetInstance();
...
... test code ...
...
Cleanup();
```
As long as each test calls Cleanup after completely done using the mtsManagerLocal instance, then this works for us. I'm not 100% sure you'll be comfortable taking a "delete Instance" in the Cleanup method. But as long as callers of Cleanup understand that it has to be the last method called on a pointer returned from GetInstance, I don't think there are problems with it.

Even if by mistake somebody else calls GetInstance after that point, it will just recreate a new one again.

We've been using this "delete Instance" commit on top of cisst 1.0.10 since last summer.