### PR TITLE
Enable sequential multiple mts manager local instances

### DIFF
--- a/cisstMultiTask/code/mtsManagerLocal.cpp
+++ b/cisstMultiTask/code/mtsManagerLocal.cpp
@@ -322,6 +322,16 @@ void mtsManagerLocal::Cleanup(void)
     __os_exit();
 }
 
+void mtsManagerLocal::DeleteInstance(void)
+{
+    if (Instance) {
+        Instance->Cleanup();
+
+        delete Instance;
+        Instance = 0;
+    }
+}
+
 const osaTimeServer & mtsManagerLocal::GetTimeServer(void) const
 {
     return TimeServer;

--- a/cisstMultiTask/mtsManagerLocal.h
+++ b/cisstMultiTask/mtsManagerLocal.h
@@ -24,7 +24,7 @@ http://www.cisst.org/cisst/license.txt.
 
   This class defines the local component manager (LCM) that manages local
   components and is unique in a process.  Since only one instance of LCM should
-  exist in a process, this class is implemented as singleton.  To get an
+  exist in a process, this class is implemented as a singleton.  To get an
   instance of LCM, therefore, mtsManagerLocal::GetInstance() should be used
   (instead of constructor).
 
@@ -447,12 +447,20 @@ public:
     /*! Call KillAll method followed by WaitForStateAll. */
     bool KillAllAndWait(double timeoutInSeconds);
 
-    /*! \brief Cleanup.  Since a local component manager is a singleton, the
-               destructor will be called when the program exits but a library
-               user is not capable of handling the timing. Thus, for safe
-               termination, this method should be called before an application
-               quits. */
+    /*! \brief Cleanup. Left in the public API for backwards compatibility.
+               Client code should not call this method directly, and should
+               instead call DeleteInstance prior to quitting. DeleteInstance
+               calls this method before deleting the singleton. */
     void Cleanup(void);
+
+    /*! \brief DeleteInstance. Since a local component manager is a singleton,
+               and demand-created by the first caller of GetInstance, the
+               destructor will never be called unless an application calls
+               this method just prior to quitting. GetInstance should NOT
+               be used again after this method is called. This method calls
+               Cleanup from its implementation, so a separate call to Cleanup
+               is unnecessary. */
+    static void DeleteInstance(void);
 
     //-------------------------------------------------------------------------
     //  Connection Management


### PR DESCRIPTION
"Re-opening" https://github.com/jhu-cisst/cisst/pull/69 since "reopen" does not seem to be available to me.

This pull request adds the static DeleteInstance method, as discussed in the comments for https://github.com/jhu-cisst/cisst/pull/69.

Questions:
- Should I put back the two mid-test-method snippets like this? (I removed them because of the comment, and because I was replacing all the other ones with final calls to DeleteInstance...)
```
    // Not really necessary, but start with a clean slate.
    localManager->RemoveAllUserComponents();
```
- Should RemoveAllUserComponents() be something that gets called for us from the "Cleanup" method?
