### PR TITLE
Minor fixes

### DIFF
--- a/cisstCommon/tests/cmnLoggerTest.cpp
+++ b/cisstCommon/tests/cmnLoggerTest.cpp
@@ -25,26 +25,38 @@ http://www.cisst.org/cisst/license.txt.
 
 void cmnLoggerTest::TestLoggerFileName(void)
 {
+    static bool setDefaultLogFileName = false;
+
     // Depending on order that tests are run, logger may already be created. This means that we
     // have to trust that cmnLogger::IsCreated is working. To run "Case 2" (logger not yet created),
     // try running just a single test
-    CPPUNIT_ASSERT_EQUAL(std::string("cisstLog.txt"), cmnLogger::GetDefaultLogFileName());
     if (cmnLogger::IsCreated()) {
         std::cout << std::endl << "TestLoggerFileName: Case 1: log file created before test" << std::endl;
-        CPPUNIT_ASSERT_EQUAL(false, cmnLogger::SetDefaultLogFileName("testLog.txt"));
-        CPPUNIT_ASSERT_EQUAL(std::string("cisstLog.txt"), cmnLogger::GetDefaultLogFileName());
     }
     else {
         std::cout << std::endl << "TestLoggerFileName: Case 2: log file not created before test" << std::endl;
-        if (cmnPath::Exists("testLog.txt"))
+        if (cmnPath::Exists("testLog.txt")) {
             std::cout << "  testLog.txt already exists -- please delete and run test again" << std::endl;
-        CPPUNIT_ASSERT_EQUAL(true, cmnLogger::SetDefaultLogFileName("testLog.txt"));
+        }
+        if (!setDefaultLogFileName) {
+            CPPUNIT_ASSERT_EQUAL(true, cmnLogger::SetDefaultLogFileName("testLog.txt"));
+            setDefaultLogFileName = true;
+        }
         CPPUNIT_ASSERT_EQUAL(std::string("testLog.txt"), cmnLogger::GetDefaultLogFileName());
         // Following call will create log file
         CMN_LOG_RUN_VERBOSE << "TestLoggerFileName: Creating log file" << std::endl;
         CPPUNIT_ASSERT_EQUAL(true, cmnLogger::IsCreated());
         CPPUNIT_ASSERT_EQUAL(true, cmnPath::Exists("testLog.txt"));
+    }
+
+    if (setDefaultLogFileName) {
+        // If already set, then setting again should do nothing and return false,
+        // regardless of the name passed in:
+        CPPUNIT_ASSERT_EQUAL(false, cmnLogger::SetDefaultLogFileName("testLog.txt"));
         CPPUNIT_ASSERT_EQUAL(false, cmnLogger::SetDefaultLogFileName("cisstLog.txt"));
         CPPUNIT_ASSERT_EQUAL(std::string("testLog.txt"), cmnLogger::GetDefaultLogFileName());
+    }
+    else {
+        CPPUNIT_ASSERT_EQUAL(std::string("cisstLog.txt"), cmnLogger::GetDefaultLogFileName());
     }
 }

--- a/cisstMultiTask/code/mtsTask.cpp
+++ b/cisstMultiTask/code/mtsTask.cpp
@@ -157,6 +157,8 @@ void mtsTask::StartupInternal(void) {
         CMN_LOG_CLASS_INIT_ERROR << "StartupInternal: task \"" << this->GetName() << "\" cannot be started." << std::endl;
     }
     CMN_LOG_CLASS_INIT_VERBOSE << "StartupInternal: ended for task \"" << this->GetName() << "\"" << std::endl;
+    // advance all state tables (if automatic)
+    StateTables.ForEachVoid(&mtsStateTable::AdvanceIfAutomatic);
     RunEvent();
 }
 


### PR DESCRIPTION
"Re-opening" https://github.com/jhu-cisst/cisst/pull/68

First commit is an AdvanceIfAutomatic call at the end of StartupInternal. We've been using it since last summer -- it fixes incorrect data being returned from a component which has been started up, but which has not yet completed its first Run method call.

Second commit is a test-only-code change so the test will pass in multiple testing scenarios. Both of the following now pass, with or without an existing **testLog.txt** file on disk:
```
cisstCommonTests.exe "-r" "-i" "2" "-o" "2" "-t" "cmnLoggerTest::TestLoggerFileName"
cisstCommonTests.exe "-r"
```
