### PR TITLE
Updates to numpy support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,10 @@ mark_as_advanced (CISST_USE_SI_UNITS)
 include (CheckSizeTNativeType)
 check_size_t_native_type (CISST_SIZE_T_NATIVE)
 
+# Determine if "long" and "long long" are different types (assume same is true
+# for "unsigned long" and "unsigned long long")
+include (CheckIfDifferentTypes)
+check_if_different_types (CISST_LONG_LONG_NATIVE "long long" "long")
 
 # Determine if we can use std::isnan and std::isfinite
 include (CheckCXXSourceCompiles)

--- a/cisstCommon/applications/cisstDataGenerator/cdgEnum.cpp
+++ b/cisstCommon/applications/cisstDataGenerator/cdgEnum.cpp
@@ -5,7 +5,7 @@
   Author(s):  Anton Deguet
   Created on: 2010-09-06
 
-  (C) Copyright 2010-2018 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2010-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -14,7 +14,6 @@ no warranty.  The complete license can be found in license.txt and
 http://www.cisst.org/cisst/license.txt.
 
 --- end cisst license ---
-
 */
 
 #include "cdgEnum.h"
@@ -26,10 +25,18 @@ CMN_IMPLEMENT_SERVICES(cdgEnum);
 cdgEnum::cdgEnum(size_t lineNumber):
     cdgScope("enum", lineNumber)
 {
+#if CMN_ASSERT_IS_DEFINED
     cdgField * field;
-    field = this->AddField("name", "", true, "name of the enum, will be added to the scope");
+    field =
+#endif
+        this->AddField("name", "", true, "name of the enum, will be added to the scope");
+
     CMN_ASSERT(field);
-    field = this->AddField("description", "", false, "description of the enum");
+
+#if CMN_ASSERT_IS_DEFINED
+    field =
+#endif
+        this->AddField("description", "", false, "description of the enum");
     CMN_ASSERT(field);
 
     this->AddKnownScope(*this);
@@ -148,7 +155,7 @@ void cdgEnum::GenerateDataFunctionsCode(std::ostream & outputStream, const std::
                      << "        return " << cScope << "::" << Scopes[index]->GetFieldValue("name") << ";" << std::endl
                      << "    };" << std::endl;
     }
-    outputStream << "    std::string message = \"" + methodName + " can't find matching enum for \" + value + \".  Options are: \"\;" << std::endl
+    outputStream << "    std::string message = \"" << methodName << " can't find matching enum for \" + value + \".  Options are: \";" << std::endl
                  << "    std::vector<std::string> options = " << name << "VectorString();" << std::endl
                  << "    for (std::vector<std::string>::const_iterator i = options.begin(); i != options.end(); ++i) message += *i + \" \";" << std::endl
                  << "    cmnThrow(message);" << std::endl

--- a/cisstCommon/applications/cisstDataGenerator/cdgEnumValue.cpp
+++ b/cisstCommon/applications/cisstDataGenerator/cdgEnumValue.cpp
@@ -5,7 +5,7 @@
   Author(s):  Anton Deguet
   Created on: 2010-09-06
 
-  (C) Copyright 2010-2018 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2010-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -14,7 +14,6 @@ no warranty.  The complete license can be found in license.txt and
 http://www.cisst.org/cisst/license.txt.
 
 --- end cisst license ---
-
 */
 
 #include "cdgEnumValue.h"
@@ -25,15 +24,26 @@ CMN_IMPLEMENT_SERVICES(cdgEnumValue);
 cdgEnumValue::cdgEnumValue(size_t lineNumber):
     cdgScope("enum-value", lineNumber)
 {
+#if CMN_ASSERT_IS_DEFINED
     cdgField * field;
-    field = this->AddField("name", "", true,
-                           "name of the enum value (e.g. enum {NAME, ...})");
+    field =
+#endif
+        this->AddField("name", "", true,
+                       "name of the enum value (e.g. enum {NAME, ...})");
     CMN_ASSERT(field);
-    field = this->AddField("description", "", false,
-                           "description of the enum");
+
+#if CMN_ASSERT_IS_DEFINED
+    field =
+#endif
+        this->AddField("description", "", false,
+                       "description of the enum");
     CMN_ASSERT(field);
-    field = this->AddField("value", "", false,
-                           "value of the enum (e.g. enum {NAME = 4})");
+
+#if CMN_ASSERT_IS_DEFINED
+    field =
+#endif
+        this->AddField("value", "", false,
+                       "value of the enum (e.g. enum {NAME = 4})");
     CMN_ASSERT(field);
     this->AddKnownScope(*this);
 }

--- a/cisstCommon/applications/cisstDataGenerator/cdgFile.cpp
+++ b/cisstCommon/applications/cisstDataGenerator/cdgFile.cpp
@@ -94,6 +94,7 @@ bool cdgFile::ParseFile(std::ifstream & input, const std::string & filename)
             break;
         case ' ':
         case '\t':
+        case '\r':
             wordFinished = true;
             break;
         case ';':

--- a/cisstCommon/applications/cisstDataGenerator/cdgInline.cpp
+++ b/cisstCommon/applications/cisstDataGenerator/cdgInline.cpp
@@ -5,7 +5,7 @@
   Author(s):  Anton Deguet
   Created on: 2010-09-06
 
-  (C) Copyright 2010-2018 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2010-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
   --- begin cisst license - do not edit ---
 
@@ -14,7 +14,6 @@
   http://www.cisst.org/cisst/license.txt.
 
   --- end cisst license ---
-
 */
 
 #include "cdgInline.h"
@@ -26,11 +25,14 @@ cdgInline::cdgInline(size_t lineNumber, InlineType type):
     cdgScope(((type == CDG_INLINE_HEADER) ? "inline-header" : "inline-code"), lineNumber),
     Type(type)
 {
+#if CMN_ASSERT_IS_DEFINED
     cdgField * field;
-    field = this->AddField("", "", false,
-                           (type == CDG_INLINE_HEADER)
-                           ? "code that will be placed as-is in the generated header file"
-                           : "code that will be placed as-is in the generated source file");
+    field =
+#endif
+        this->AddField("", "", false,
+                       (type == CDG_INLINE_HEADER)
+                       ? "code that will be placed as-is in the generated header file"
+                       : "code that will be placed as-is in the generated source file");
     CMN_ASSERT(field);
 
     this->AddKnownScope(*this);

--- a/cisstCommon/applications/cisstDataGenerator/cdgTypedef.cpp
+++ b/cisstCommon/applications/cisstDataGenerator/cdgTypedef.cpp
@@ -5,7 +5,7 @@
   Author(s):  Anton Deguet
   Created on: 2010-09-06
 
-  (C) Copyright 2010-2018 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2010-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -14,7 +14,6 @@ no warranty.  The complete license can be found in license.txt and
 http://www.cisst.org/cisst/license.txt.
 
 --- end cisst license ---
-
 */
 
 #include "cdgTypedef.h"
@@ -25,12 +24,19 @@ CMN_IMPLEMENT_SERVICES(cdgTypedef);
 cdgTypedef::cdgTypedef(size_t lineNumber):
     cdgScope("typedef", lineNumber)
 {
+#if CMN_ASSERT_IS_DEFINED
     cdgField * field;
-    field = this->AddField("name", "", true,
-                           "name of the new type defined");
+    field =
+#endif
+        this->AddField("name", "", true,
+                       "name of the new type defined");
     CMN_ASSERT(field);
-    field = this->AddField("type", "", true,
-                           "C/C++ type used to define the new type");
+
+#if CMN_ASSERT_IS_DEFINED
+    field =
+#endif
+        this->AddField("type", "", true,
+                       "C/C++ type used to define the new type");
     CMN_ASSERT(field);
 
     this->AddKnownScope(*this);

--- a/cisstCommon/cmnAssert.h
+++ b/cisstCommon/cmnAssert.h
@@ -5,7 +5,7 @@
   Author(s):  Ankur Kapoor
   Created on: 2003-06-25
 
-  (C) Copyright 2003-2016 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2003-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -14,7 +14,6 @@ no warranty.  The complete license can be found in license.txt and
 http://www.cisst.org/cisst/license.txt.
 
 --- end cisst license ---
-
 */
 
 
@@ -66,11 +65,19 @@ http://www.cisst.org/cisst/license.txt.
   API with OK button for release builds and message box API with
   "Abort, Ignore, Retry" for debug builds.
 
+  \note To determine if CMN_ASSERT is defined, CMN_ASSERT_IS_DEFINED
+  is define as 1, 0 otherwise.  This can be used to conditionally
+  declare variables that are only used by CMN_ASSERT and avoid
+  compiler warnings regarding unused variables.
+
   \sa cmnThrow
 */
 #if defined(CISST_CMN_ASSERT_DISABLED) || defined(NDEBUG)
-    #define CMN_ASSERT(expr)
+  #define CMN_ASSERT_IS_DEFINED 0
+  #define CMN_ASSERT(expr)
 #else // CISST_CMN_ASSERT_DISABLED || NDEBUG
+
+  #define CMN_ASSERT_IS_DEFINED 1
 
 #ifdef CISST_CMN_ASSERT_THROWS_EXCEPTION
 

--- a/cisstCommon/tests/cmnPortabilityTest.cpp
+++ b/cisstCommon/tests/cmnPortabilityTest.cpp
@@ -150,6 +150,7 @@ void cmnPortabilityTest::TestCMN_ISFINITE(void) {
 
 void cmnPortabilityTest::TestDataModel(void) {
 #if (CISST_DATA_MODEL == CISST_ILP32)
+    cout << std::endl << "Cisst data model: ILP32" << std::endl;
     CPPUNIT_ASSERT(4 == sizeof(int));
     CPPUNIT_ASSERT(4 == sizeof(unsigned int));
     CPPUNIT_ASSERT(4 == sizeof(long));
@@ -161,6 +162,7 @@ void cmnPortabilityTest::TestDataModel(void) {
     CPPUNIT_ASSERT(4 == sizeof(ptrdiff_t));
 #endif
 #if (CISST_DATA_MODEL == CISST_LP64)
+    cout << std::endl << "Cisst data model: LP64" << std::endl;
     CPPUNIT_ASSERT(4 == sizeof(int));
     CPPUNIT_ASSERT(4 == sizeof(unsigned int));
     CPPUNIT_ASSERT(8 == sizeof(long));
@@ -172,6 +174,7 @@ void cmnPortabilityTest::TestDataModel(void) {
     CPPUNIT_ASSERT(8 == sizeof(ptrdiff_t));
 #endif
 #if (CISST_DATA_MODEL == CISST_LLP64)
+    cout << std::endl << "Cisst data model: LLP64" << std::endl;
     CPPUNIT_ASSERT(4 == sizeof(int));
     CPPUNIT_ASSERT(4 == sizeof(unsigned int));
     CPPUNIT_ASSERT(4 == sizeof(long));

--- a/cisstConfig.h.in
+++ b/cisstConfig.h.in
@@ -48,6 +48,9 @@ http://www.cisst.org/cisst/license.txt.
 // To allow overloading of functions for size_t
 #cmakedefine01 CISST_SIZE_T_NATIVE
 
+// To allow overloading of functions for long long (and unsigned long long)
+#cmakedefine01 CISST_LONG_LONG_NATIVE
+
 // Can we use cmath  std::isnan
 #cmakedefine01 CISST_HAS_STD_ISNAN
 

--- a/cisstMultiTask/code/mtsManagerGlobal.cpp
+++ b/cisstMultiTask/code/mtsManagerGlobal.cpp
@@ -2,7 +2,6 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-
   Author(s):  Min Yang Jung
   Created on: 2009-11-12
 
@@ -1335,8 +1334,8 @@ ConnectionIDType mtsManagerGlobal::Connect(const std::string & requestProcessNam
         // Thus, a required interface proxy is created whenever a new connection is
         // established while a provided interface proxy is created only once when
         // a client component does not have it.
-        // 
-        // MJ (3/30/11): DESIGN CHANGE: For each connection, create a new provided interface 
+        //
+        // MJ (3/30/11): DESIGN CHANGE: For each connection, create a new provided interface
         // proxy "instance" to fix the thread-safety issue (i.e., shared
         // serializer/deserializer of command proxy objects) and to potentially support
         // blocking commands and uni-cast events.  This also resolves the duplicate broadcast
@@ -1634,7 +1633,7 @@ bool mtsManagerGlobal::ConnectConfirm(const ConnectionIDType connectionID)
 
     CMN_LOG_CLASS_INIT_VERBOSE << "ConnectConfirm: confirmed connection id [ " << connectionID << " ]" << std::endl;
 
-    // MJ: for testing and debugging 
+    // MJ: for testing and debugging
     //ShowInternalStructure();
 
     return true;
@@ -1724,7 +1723,7 @@ void mtsManagerGlobal::DisconnectInternal(void)
 
 #if CISST_MTS_HAS_ICE
         if (!localConfiguration) {
-            serverInterfaceName = 
+            serverInterfaceName =
                 mtsComponentProxy::GetNameOfProvidedInterfaceInstance(serverInterfaceName, connectionID);
         }
 #else
@@ -1884,7 +1883,7 @@ void mtsManagerGlobal::DisconnectInternal(void)
 
             // Naming rule for provided interface instances does not apply to the MCS in the GCM
             if (serverProcessName == mtsManagerLocal::ProcessNameOfLCMWithGCM &&
-                serverComponentName == mtsManagerComponentBase::ComponentNames::ManagerComponentServer) 
+                serverComponentName == mtsManagerComponentBase::ComponentNames::ManagerComponentServer)
             {
                 serverInterfaceName = mtsManagerComponentBase::InterfaceNames::InterfaceGCMProvided;
             }
@@ -2016,7 +2015,10 @@ void mtsManagerGlobal::DisconnectInternal(void)
 
         // enqueue id to disconnected queue
         // MJ: this is redundant check but intentionally added to make sure things work correctly
-        DisconnectQueueType::const_iterator itDisconnected = QueueDisconnected.find(connectionID);
+#if CMN_ASSERT_IS_DEFINED
+        DisconnectQueueType::const_iterator itDisconnected =
+#endif
+            QueueDisconnected.find(connectionID);
         CMN_ASSERT(itDisconnected == QueueDisconnected.end());
         QueueDisconnected.insert(std::make_pair(connectionID, connectionID));
 
@@ -2029,7 +2031,7 @@ void mtsManagerGlobal::DisconnectInternal(void)
                                 << clientComponentName << ":" << clientInterfaceName << "\"" << std::endl;
     }
 
-    // MJ: for testing and debugging 
+    // MJ: for testing and debugging
     //ShowInternalStructure();
 }
 

--- a/cisstMultiTask/code/mtsManagerLocal.cpp
+++ b/cisstMultiTask/code/mtsManagerLocal.cpp
@@ -1245,7 +1245,10 @@ mtsComponent * mtsManagerLocal::CreateComponentDynamicallyJSON(const std::string
     Json::Value jsonValue;
     Json::Reader reader;
     // parsing should work since the string has been generated after a previous parse
-    bool parsedOk = reader.parse(constructorArgSerialized, jsonValue);
+#if CMN_ASSERT_IS_DEFINED
+    bool parsedOk =
+#endif
+        reader.parse(constructorArgSerialized, jsonValue);
     CMN_ASSERT(parsedOk);
     try {
         argument->DeSerializeTextJSON(jsonValue);

--- a/cisstNumerical/nmrInverse.h
+++ b/cisstNumerical/nmrInverse.h
@@ -5,7 +5,7 @@
   Author(s):  Anton Deguet
   Created on: 2006-01-27
 
-  (C) Copyright 2006-2018 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2006-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -695,7 +695,9 @@ inline CISSTNETLIB_INTEGER nmrInverse(vctFixedSizeMatrix<CISSTNETLIB_DOUBLE, _si
                             vctFixedSizeVector<CISSTNETLIB_INTEGER, _maxSize1> & pivotIndices,
                             vctFixedSizeVector<CISSTNETLIB_DOUBLE, _lWork> & workspace)
 {
+#if CMN_ASSERT_IS_DEFINED
     const CISSTNETLIB_INTEGER maxSize1 = static_cast<CISSTNETLIB_INTEGER>(nmrInverseFixedSizeData<_size, _storageOrder>::MAX_SIZE_1);
+#endif
     const CISSTNETLIB_INTEGER lWork = static_cast<CISSTNETLIB_INTEGER>(nmrInverseFixedSizeData<_size, _storageOrder>::LWORK);
     //Assert if requirement is equal to size provided!
     CMN_ASSERT(maxSize1 == static_cast<CISSTNETLIB_INTEGER>(_maxSize1));
@@ -783,4 +785,3 @@ inline CISSTNETLIB_INTEGER nmrInverse(vctFixedSizeMatrix<CISSTNETLIB_DOUBLE, _si
 
 
 #endif // _nmrInverse_h
-

--- a/cisstNumerical/nmrLU.h
+++ b/cisstNumerical/nmrLU.h
@@ -5,7 +5,7 @@
   Author(s): Anton Deguet
   Created on: 2006-01-10
 
-  (C) Copyright 2006-2018 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2006-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -183,7 +183,7 @@ public:
     /*! Helper method to compute the size of the matrix L.  This
       method can be used before UpdateMatrixLU to make sure that the
       size of L is correct.
-      
+
       \param A The matrix to be decomposed using ::nmrLU (it is used
       only to determine the sizes).
     */
@@ -199,7 +199,7 @@ public:
     /*! Helper method to compute the size of the matrix U.  This
       method can be used before UpdateMatrixLU to make sure that the
       size of U is correct.
-      
+
       \param A The matrix to be decomposed using ::nmrLU (it is used
       only to determine the sizes).
     */
@@ -214,7 +214,7 @@ public:
 
     /*! Helper method to create a usable permutation matrix from the
       vector of pivot indices created by ::nmrLU.
-      
+
       \note This method must be called after the ::nmrLU function has been called.
 
       \param A The matrix decomposed using ::nmrLU.  It is used only to check the sizes.
@@ -230,7 +230,7 @@ public:
         CISST_THROW(std::runtime_error)
     {
         const size_type minmn = (A.rows() < A.cols()) ? A.rows() : A.cols();
-        // check sizes 
+        // check sizes
         if (pivotIndices.size() != minmn) {
             cmnThrow(std::runtime_error("nmrLUDynamicData::UpdateMatrixP: Size of vector pivotIndices is incorrect."));
         }
@@ -255,7 +255,7 @@ public:
       and upper parts respectively in L and U, setting all other
       elements to zero.  The diagonal of the output is copied to U
       while all the elements of the diagonal of L are set to 1.
-      
+
       \note This method must be called after the ::nmrLU function has been called.
 
       \param A The matrix decomposed using ::nmrLU.
@@ -263,7 +263,7 @@ public:
       \param U The upper matrix
     */
     template <class _matrixOwnerTypeA, class _matrixOwnerTypeL, class _matrixOwnerTypeU>
-    static inline 
+    static inline
     void UpdateMatrixLU(const vctDynamicConstMatrixBase<_matrixOwnerTypeA, CISSTNETLIB_DOUBLE> & A,
                         vctDynamicMatrixBase<_matrixOwnerTypeL, CISSTNETLIB_DOUBLE> & L,
                         vctDynamicMatrixBase<_matrixOwnerTypeU, CISSTNETLIB_DOUBLE> & U)
@@ -284,7 +284,7 @@ public:
                 }
             }
         }
- 
+
     }
 
 
@@ -343,7 +343,7 @@ public:
     {
         this->Allocate(m, n);
     }
-    
+
     /*! Constructor where the user provides the input matrix to
       specify the size and storage order.  Memory allocation is
       performed for pivot indices vector. This should be used when the
@@ -358,16 +358,16 @@ public:
     {
         this->Allocate(A);
     }
-    
+
     /*! Constructor where the user provides the vector to store the
       pivot indices.  The data object now acts as a composite
       container to hold, pass and manipulate a convenient storage for
       LU algorithm. Checks are made on the validity of the input and
       its consitency in terms of size.
-      
+
       \param A The matrix to be decomposed, used to verify the sizes.
       \param pivotIndices Vector created by the user to store the output.
- 
+
       \sa nmrLUDynamicData::SetRef
     */
     template <class _matrixOwnerTypeA,
@@ -392,7 +392,7 @@ public:
     {
         this->Allocate(A.rows(), A.cols());
     }
-    
+
     /*! This method allocates the memory for the output (pivot
       indices).  This method is not meant to be a top-level user API,
       but is used by other overloaded Allocate methods.
@@ -405,7 +405,7 @@ public:
         this->SetDimension(m, n);
         this->AllocateOutput(true);
     }
-    
+
     /*! This method doesn't allocate any memory as it relies on the user
       provided vector (pivotIndices).
 
@@ -428,7 +428,7 @@ public:
         this->ThrowUnlessOutputSizeIsCorrect(pivotIndices);
         this->PivotIndicesReference.SetRef(pivotIndices);
     }
-    
+
     /*! Const reference to the result vector PivotIndices.  This
       method must be called after the data has been computed by
       the nmrLU function. */
@@ -439,7 +439,7 @@ public:
 
 
 
-/*! 
+/*!
   \ingroup cisstNumerical
 
   \brief Data of LU problem (Fixed size).
@@ -452,7 +452,7 @@ public:
   \code
   nmrLUFixedSizeData<4, 3> data;
   \endcode
-  
+
   \note An object of type nmrLUFixedSizeData contains the memory
   required for the output, i.e. its actual size will be equal to the
   memory required to store the vector PivotIndices.
@@ -490,7 +490,7 @@ public:
 
 protected:
     VectorTypePivotIndices PivotIndicesMember; /*!< Data member used to store the output vector PivotIndices. */
-    
+
 public:
 #ifndef DOXYGEN
     /*! This class is not intended to be a top-level API.  It has been
@@ -511,22 +511,22 @@ public:
     };
     friend class Friend;
 #endif // DOXYGEN
-    
+
     /*! Default constructor.  Does nothing since the allocation is
       performed on the stack. */
     nmrLUFixedSizeData() {};
-    
+
     /*! Const reference to the result vector PivotIndices.  This
       method must be called after the data has been computed by
       the nmrLU function. */
     inline const VectorTypePivotIndices & PivotIndices(void) const {
         return PivotIndicesMember;
     }
-    
+
 
     /*! Helper method to create a usable permutation matrix from the
       vector of pivot indices created by ::nmrLU.
-      
+
       \note This method must be called after the ::nmrLU function has been called.
 
       \param pivotIndices The vector of pivot indices as computed by ::nmrLU
@@ -556,14 +556,14 @@ public:
       and upper parts respectively in L and U, setting all other
       elements to zero.  The diagonal of the output is copied to U
       while all the elements of the diagonal of L are set to 1.
-      
+
       \note This method must be called after the ::nmrLU function has been called.
 
       \param A The matrix decomposed using ::nmrLU.
       \param L The lower matrix
       \param U The upper matrix
     */
-    static inline 
+    static inline
     void UpdateMatrixLU(const MatrixTypeA & A,
                         MatrixTypeL & L,
                         MatrixTypeU & U)
@@ -702,7 +702,7 @@ public:
   This function checks for valid input (size and compact) and calls
   the LAPACK function.  If the input doesn't match the data, an
   exception is thrown (\c std::runtime_error).
-  
+
   This function modifies the input matrix A and stores the results in
   the data.  The result can be obtained via the const method
   nmrLUDynamicData::PivotIndices().
@@ -763,7 +763,7 @@ inline CISSTNETLIB_INTEGER nmrLU(vctDynamicMatrixBase<_matrixOwnerType, CISSTNET
   user (see nmrLUDynamicData::SetRef).  While the data is
   being build, the consistency of the output is checked.  Then, the
   nmrLU(A, data) function can be used safely.
- 
+
   \param A is a reference to a dynamic matrix of size MxN
   \param pivotIndices Vector created by the user to store the pivot indices.
 
@@ -791,7 +791,7 @@ inline CISSTNETLIB_INTEGER nmrLU(vctDynamicMatrixBase<_matrixOwnerTypeA, CISSTNE
   do if the sizes don't match.  By default CMN_ASSERT calls \c abort()
   but it can be configured to be ignored or to throw an exception (see
   #CMN_ASSERT for details).
-  
+
   This function modifies the input matrix A.  It stores the result in
   pivotIndices and A which now contains the elements of both L and U.
   The methods UpdateMatrixLU and UpdateMatrixP can ease the creation
@@ -806,10 +806,12 @@ inline CISSTNETLIB_INTEGER nmrLU(vctDynamicMatrixBase<_matrixOwnerTypeA, CISSTNE
         nmrLUTest::TestFixedSizeUserOutputColumnMajorMGeqN
  */
 template <vct::size_type _rows, vct::size_type _cols, vct::size_type _minmn>
-inline CISSTNETLIB_INTEGER nmrLU(vctFixedSizeMatrix<CISSTNETLIB_DOUBLE, _rows, _cols, VCT_COL_MAJOR> & A, 
+inline CISSTNETLIB_INTEGER nmrLU(vctFixedSizeMatrix<CISSTNETLIB_DOUBLE, _rows, _cols, VCT_COL_MAJOR> & A,
                        vctFixedSizeVector<CISSTNETLIB_INTEGER, _minmn> & pivotIndices)
 {
+#if CMN_ASSERT_IS_DEFINED
     const CISSTNETLIB_INTEGER minmn = static_cast<CISSTNETLIB_INTEGER>(nmrLUFixedSizeData<_rows, _cols>::MIN_MN);
+#endif
     //Assert if requirement is equal to size provided!
     CMN_ASSERT(minmn == static_cast<CISSTNETLIB_INTEGER>(_minmn));
 
@@ -868,4 +870,3 @@ inline CISSTNETLIB_INTEGER nmrLU(vctFixedSizeMatrix<CISSTNETLIB_DOUBLE, _rows, _
 
 
 #endif // _nmrLU_h
-

--- a/cisstNumerical/nmrPInverse.h
+++ b/cisstNumerical/nmrPInverse.h
@@ -5,7 +5,7 @@
   Author(s):  Ankur Kapoor
   Created on: 2005-10-18
 
-  (C) Copyright 2005-2018 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2005-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -894,7 +894,9 @@ inline CISSTNETLIB_INTEGER nmrPInverse(vctFixedSizeMatrix<CISSTNETLIB_DOUBLE, _r
                              vctFixedSizeVectorBase<_work, 1, CISSTNETLIB_DOUBLE, _dataPtrType> & workspace)
 {
     typedef vct::size_type size_type;
+#if CMN_ASSERT_IS_DEFINED
     const size_type lwork = nmrPInverseFixedSizeData<_rows, _cols, _storageOrder>::LWORK;
+#endif
     const size_type lwork_3 = nmrPInverseFixedSizeData<_rows, _cols, _storageOrder>::LWORK_3;
     const size_type minmn = nmrPInverseFixedSizeData<_rows, _cols, _storageOrder>::MIN_MN;
     const size_type maxmn = (_rows > _cols) ? _rows : _cols;

--- a/cisstNumerical/nmrSVD.h
+++ b/cisstNumerical/nmrSVD.h
@@ -5,7 +5,7 @@
   Author(s):  Ankur Kapoor, Anton Deguet
   Created on: 2005-10-18
 
-  (C) Copyright 2005-2018 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2005-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -1174,8 +1174,10 @@ CISSTNETLIB_INTEGER nmrSVD(vctFixedSizeMatrix<CISSTNETLIB_DOUBLE, _rows, _cols, 
                            vctFixedSizeMatrix<CISSTNETLIB_DOUBLE, _cols, _cols, _storageOrder> & Vt,
                            vctFixedSizeVector<CISSTNETLIB_DOUBLE, _work> & workspace)
 {
+#if CMN_ASSERT_IS_DEFINED
     const CISSTNETLIB_INTEGER minmn =
         static_cast<CISSTNETLIB_INTEGER>(nmrSVDFixedSizeData<_rows, _cols, _storageOrder>::MIN_MN);
+#endif
     //Assert if requirement is greater than size provided!
     CMN_ASSERT(minmn <= static_cast<CISSTNETLIB_INTEGER>(_minmn));
     CISSTNETLIB_INTEGER ldu = (_storageOrder == VCT_COL_MAJOR) ? _rows : _cols;

--- a/cisstOSAbstraction/code/osaPipeExec.cpp
+++ b/cisstOSAbstraction/code/osaPipeExec.cpp
@@ -2,7 +2,6 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-
   Author(s): Martin Kelly
   Created on: 2010-09-23
 
@@ -15,7 +14,6 @@
   http://www.cisst.org/cisst/license.txt.
 
   --- end cisst license ---
-
 */
 
 #include <cisstCommon/cmnAssert.h>
@@ -90,8 +88,10 @@ int osaPipeExec::DoClose(int &n)
 #else
         int ret = -1;
 #endif
-        if (ret == -1)
-            CMN_LOG_RUN_WARNING << "osaPipeExec: failed to close handle" << std::endl;
+        if (ret == -1) {
+            CMN_LOG_RUN_WARNING << "osaPipeExec: failed to close handle for \""
+                                << this->Name << "\"" << std::endl;
+        }
         n = -1;
     }
     return ret;
@@ -245,7 +245,7 @@ bool osaPipeExec::Open(const std::string & executable,
         CloseAllPipes();
         exit(-1);  // terminate the child program
     }
-    
+
 #elif (CISST_OS == CISST_WINDOWS)
     // On Windows, there are two implementations.
     //   noWindow:  This is a newer implementation that calls CreatePipe and CreateProcess, passing the

--- a/cisstStereoVision/cisstStereoVision.i
+++ b/cisstStereoVision/cisstStereoVision.i
@@ -2,12 +2,10 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-  $Id$
-
   Author(s):	Anton Deguet
   Created on:   2009-01-26
 
-  (C) Copyright 2006-2013 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2006-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -149,7 +147,7 @@ PyObject* convert_vctDynamicMatrixRef_to_PyObject(vctDynamicMatrixRef<__ValueTyp
     const npy_intp size1 = matrix_in.cols();
     const npy_intp stride0 = size1;
     const npy_intp stride1 = 1;
-    __ValueType * data = reinterpret_cast<__ValueType *>(PyArray_DATA(result));
+    __ValueType * data = reinterpret_cast<__ValueType *>(PyArray_DATA(reinterpret_cast<PyArrayObject *>(result)));
 
     vctDynamicMatrixRef<__ValueType> tempContainer(size0, size1, stride0, stride1, data);
 

--- a/cisstVector/testsPython/vctDynamicMatrixTypemapsTest.h
+++ b/cisstVector/testsPython/vctDynamicMatrixTypemapsTest.h
@@ -2,12 +2,10 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-
   Author(s):  Daniel Li, Anton Deguet
   Created on: 2009-05-20
 
-  (C) Copyright 2009 Johns Hopkins University (JHU), All Rights
-  Reserved.
+  (C) Copyright 2009-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -16,7 +14,6 @@ no warranty.  The complete license can be found in license.txt and
 http://www.cisst.org/cisst/license.txt.
 
 --- end cisst license ---
-
 */
 
 
@@ -126,12 +123,12 @@ public:
     }
 
     inline _elementType GetItem(size_type rowIndex, size_type colIndex) const
-    throw(std::out_of_range) {
+    CISST_THROW (std::out_of_range) {
         return copy.at(rowIndex, colIndex);
     }
 
     inline void SetItem(size_type rowIndex, size_type colIndex, _elementType value)
-    throw(std::out_of_range) {
+    CISST_THROW (std::out_of_range) {
         copy.at(rowIndex, colIndex) = value;
     }
 

--- a/cisstVector/testsPython/vctDynamicNArrayTypemapsTest.h
+++ b/cisstVector/testsPython/vctDynamicNArrayTypemapsTest.h
@@ -2,12 +2,10 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-
   Author(s):  Daniel Li, Anton Deguet
   Created on: 2009-05-20
 
-  (C) Copyright 2009 Johns Hopkins University (JHU), All Rights
-  Reserved.
+  (C) Copyright 2009-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -16,7 +14,6 @@ no warranty.  The complete license can be found in license.txt and
 http://www.cisst.org/cisst/license.txt.
 
 --- end cisst license ---
-
 */
 
 
@@ -129,12 +126,12 @@ public:
     }
 
     inline _elementType GetItem(const vct::size_type metaIndex) const
-    throw(std::out_of_range) {
+    CISST_THROW (std::out_of_range) {
         return copy.at(metaIndex);
     }
 
     inline void SetItem(const vct::size_type metaIndex, _elementType value)
-    throw(std::out_of_range) {
+    CISST_THROW (std::out_of_range) {
         copy.at(metaIndex) = value;
     }
 
@@ -145,5 +142,4 @@ public:
     inline static int sizeOfSizes(void) {
         return sizeof(vct::size_type);
     }
-   
 };

--- a/cisstVector/testsPython/vctDynamicVectorTypemapsTest.h
+++ b/cisstVector/testsPython/vctDynamicVectorTypemapsTest.h
@@ -2,12 +2,10 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-
   Author(s):  Daniel Li, Anton Deguet
   Created on: 2009-05-20
 
-  (C) Copyright 2009 Johns Hopkins University (JHU), All Rights
-  Reserved.
+  (C) Copyright 2009-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -16,7 +14,6 @@ no warranty.  The complete license can be found in license.txt and
 http://www.cisst.org/cisst/license.txt.
 
 --- end cisst license ---
-
 */
 
 
@@ -124,12 +121,12 @@ public:
     }
 
     inline _elementType __getitem__(size_type index) const
-    throw(std::out_of_range) {
+    CISST_THROW (std::out_of_range) {
         return copy.at(index);
     }
 
     inline void __setitem__(size_type index, _elementType value)
-    throw(std::out_of_range) {
+    CISST_THROW (std::out_of_range) {
         copy.at(index) = value;
     }
 

--- a/cisstVector/testsPython/vctFixedSizeMatrixTypemapsTest.h
+++ b/cisstVector/testsPython/vctFixedSizeMatrixTypemapsTest.h
@@ -2,12 +2,10 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-
   Author(s):  Daniel Li, Anton Deguet
   Created on: 2009-05-20
 
-  (C) Copyright 2009 Johns Hopkins University (JHU), All Rights
-  Reserved.
+  (C) Copyright 2009-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -16,7 +14,6 @@ no warranty.  The complete license can be found in license.txt and
 http://www.cisst.org/cisst/license.txt.
 
 --- end cisst license ---
-
 */
 
 
@@ -77,12 +74,12 @@ public:
     }
 
     inline _elementType GetItem(vct::size_type rowIndex, vct::size_type colIndex) const
-    throw(std::out_of_range) {
+    CISST_THROW (std::out_of_range) {
         return copy.at(rowIndex, colIndex);
     }
 
     inline void SetItem(vct::size_type rowIndex, vct::size_type colIndex, _elementType value)
-    throw(std::out_of_range) {
+    CISST_THROW (std::out_of_range) {
         copy.at(rowIndex, colIndex) = value;
     }
 

--- a/cisstVector/testsPython/vctFixedSizeVectorTypemapsTest.h
+++ b/cisstVector/testsPython/vctFixedSizeVectorTypemapsTest.h
@@ -2,12 +2,10 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-
   Author(s):  Daniel Li, Anton Deguet
   Created on: 2009-05-20
 
-  (C) Copyright 2009 Johns Hopkins University (JHU), All Rights
-  Reserved.
+  (C) Copyright 2009-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -16,7 +14,6 @@ no warranty.  The complete license can be found in license.txt and
 http://www.cisst.org/cisst/license.txt.
 
 --- end cisst license ---
-
 */
 
 
@@ -76,12 +73,12 @@ public:
     }
 
     inline _elementType __getitem__(vct::size_type index) const
-    throw(std::out_of_range) {
+    CISST_THROW (std::out_of_range) {
         return copy.at(index);
     }
 
     inline void __setitem__(vct::size_type index, _elementType value)
-    throw(std::out_of_range) {
+    CISST_THROW (std::out_of_range) {
         copy.at(index) = value;
     }
 

--- a/cisstVector/vctDynamicMatrixTypemaps.i
+++ b/cisstVector/vctDynamicMatrixTypemaps.i
@@ -2,13 +2,10 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-  $Id$
-
   Author(s):  Daniel Li, Anton Deguet
   Created on: 2009-05-20
 
-  (C) Copyright 2009-2013 Johns Hopkins University (JHU), All Rights
-  Reserved.
+  (C) Copyright 2009-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -65,8 +62,8 @@ http://www.cisst.org/cisst/license.txt.
     typedef $1_ltype MatrixType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<MatrixType::value_type>($input)
-          && vctThrowUnlessDimension2($input)
-          && vctThrowUnlessCorrectMatrixSize($input, $1))
+          && vctThrowUnlessDimension2(cast_array($input))
+          && vctThrowUnlessCorrectMatrixSize(cast_array($input), $1))
         ) {
           return NULL;
     }
@@ -76,11 +73,11 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // Create a temporary vctDynamicMatrixRef container
-    const npy_intp size0 = PyArray_DIM($input, 0);
-    const npy_intp size1 = PyArray_DIM($input, 1);
-    const npy_intp stride0 = PyArray_STRIDE($input, 0) / sizeof(MatrixType::value_type);
-    const npy_intp stride1 = PyArray_STRIDE($input, 1) / sizeof(MatrixType::value_type);
-    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA($input));
+    const npy_intp size0 = PyArray_DIM(cast_array($input), 0);
+    const npy_intp size1 = PyArray_DIM(cast_array($input), 1);
+    const npy_intp stride0 = PyArray_STRIDE(cast_array($input), 0) / sizeof(MatrixType::value_type);
+    const npy_intp stride1 = PyArray_STRIDE(cast_array($input), 1) / sizeof(MatrixType::value_type);
+    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA(cast_array($input)));
 
     const vctDynamicMatrixRef<MatrixType::value_type> tempContainer(size0, size1, stride0, stride1, data);
 
@@ -115,11 +112,11 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // Create a temporary vctDynamicMatrixRef container
-    const npy_intp size0 = PyArray_DIM($result, 0);
-    const npy_intp size1 = PyArray_DIM($result, 1);
-    const npy_intp stride0 = PyArray_STRIDE($result, 0) / sizeof(MatrixType::value_type);
-    const npy_intp stride1 = PyArray_STRIDE($result, 1) / sizeof(MatrixType::value_type);
-    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA($result));
+    const npy_intp size0 = PyArray_DIM(cast_array($result), 0);
+    const npy_intp size1 = PyArray_DIM(cast_array($result), 1);
+    const npy_intp stride0 = PyArray_STRIDE(cast_array($result), 0) / sizeof(MatrixType::value_type);
+    const npy_intp stride1 = PyArray_STRIDE(cast_array($result), 1) / sizeof(MatrixType::value_type);
+    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA(cast_array($result)));
 
     vctDynamicMatrixRef<MatrixType::value_type> tempContainer(size0, size1, stride0, stride1, data);
 
@@ -151,10 +148,10 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype MatrixType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<MatrixType::value_type>($input)
-          && vctThrowUnlessDimension2($input)
-          && vctThrowUnlessCorrectMatrixSize($input, *($1))
-          && vctThrowUnlessIsWritable($input)
-          && vctThrowUnlessOwnsData($input, *($1))
+          && vctThrowUnlessDimension2(cast_array($input))
+          && vctThrowUnlessCorrectMatrixSize(cast_array($input), *($1))
+          && vctThrowUnlessIsWritable(cast_array($input))
+          && vctThrowUnlessOwnsData(cast_array($input), *($1))
           && vctThrowUnlessNotReferenced($input, *($1)))
         ) {
           return NULL;
@@ -165,11 +162,11 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // Create a temporary vctDynamicMatrixRef container
-    const npy_intp size0 = PyArray_DIM($input, 0);
-    const npy_intp size1 = PyArray_DIM($input, 1);
-    const npy_intp stride0 = PyArray_STRIDE($input, 0) / sizeof(MatrixType::value_type);
-    const npy_intp stride1 = PyArray_STRIDE($input, 1) / sizeof(MatrixType::value_type);
-    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA($input));
+    const npy_intp size0 = PyArray_DIM(cast_array($input), 0);
+    const npy_intp size1 = PyArray_DIM(cast_array($input), 1);
+    const npy_intp stride0 = PyArray_STRIDE(cast_array($input), 0) / sizeof(MatrixType::value_type);
+    const npy_intp stride1 = PyArray_STRIDE(cast_array($input), 1) / sizeof(MatrixType::value_type);
+    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA(cast_array($input)));
 
     const vctDynamicMatrixRef<MatrixType::value_type> tempContainer(size0, size1, stride0, stride1, data);
 
@@ -193,8 +190,8 @@ http://www.cisst.org/cisst/license.txt.
     *************************************************************************/
 
     typedef $*1_ltype MatrixType;
-    const MatrixType::size_type input_size0 = PyArray_DIM($input, 0);
-    const MatrixType::size_type input_size1 = PyArray_DIM($input, 1);
+    const MatrixType::size_type input_size0 = PyArray_DIM(cast_array($input), 0);
+    const MatrixType::size_type input_size1 = PyArray_DIM(cast_array($input), 1);
     const MatrixType::size_type output_size0 = $1->sizes()[0];
     const MatrixType::size_type output_size1 = $1->sizes()[1];
 
@@ -210,7 +207,7 @@ http://www.cisst.org/cisst/license.txt.
         PyArray_Dims dims;                              // create a PyArray_Dims object to hand to PyArray_Resize
         dims.ptr = sizes;
         dims.len = 2;
-        PyArray_Resize((PyArrayObject *) $input, &dims, 0, NPY_CORDER);
+        PyArray_Resize(cast_array($input), &dims, 0, NPY_CORDER);
     }
 
     /*************************************************************************
@@ -218,11 +215,11 @@ http://www.cisst.org/cisst/license.txt.
     *************************************************************************/
 
     // Create a temporary vctDynamicMatrixRef container
-    const npy_intp size0 = PyArray_DIM($input, 0);
-    const npy_intp size1 = PyArray_DIM($input, 1);
-    const npy_intp stride0 = PyArray_STRIDE($input, 0) / sizeof(MatrixType::value_type);
-    const npy_intp stride1 = PyArray_STRIDE($input, 1) / sizeof(MatrixType::value_type);
-    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA($input));
+    const npy_intp size0 = PyArray_DIM(cast_array($input), 0);
+    const npy_intp size1 = PyArray_DIM(cast_array($input), 1);
+    const npy_intp stride0 = PyArray_STRIDE(cast_array($input), 0) / sizeof(MatrixType::value_type);
+    const npy_intp stride1 = PyArray_STRIDE(cast_array($input), 1) / sizeof(MatrixType::value_type);
+    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA(cast_array($input)));
 
     vctDynamicMatrixRef<MatrixType::value_type> tempContainer(size0, size1, stride0, stride1, data);
 
@@ -253,7 +250,7 @@ http://www.cisst.org/cisst/license.txt.
     // Look at the NumPy C API to see how these lines work: http://projects.scipy.org/numpy/wiki/NumPyCAPI
     int type = vctPythonType<MatrixType::value_type>();
     PyArray_Descr *descr = PyArray_DescrFromType(type);
-    $result = PyArray_NewFromDescr(&PyArray_Type, descr, 2, sizes, NULL, $1->Pointer(), $1->StorageOrder() ? NPY_CARRAY : NPY_FARRAY, NULL);
+    $result = PyArray_NewFromDescr(&PyArray_Type, descr, 2, sizes, NULL, $1->Pointer(), $1->StorageOrder() ? NPY_ARRAY_CARRAY : NPY_ARRAY_FARRAY, NULL);
 }
 
 
@@ -280,8 +277,8 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype MatrixType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<MatrixType::value_type>($input)
-          && vctThrowUnlessDimension2($input)
-          && vctThrowUnlessCorrectMatrixSize($input, *($1)))
+          && vctThrowUnlessDimension2(cast_array($input))
+          && vctThrowUnlessCorrectMatrixSize(cast_array($input), *($1)))
         ) {
           return NULL;
     }
@@ -291,11 +288,11 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // Create a temporary vctDynamicMatrixRef container
-    const npy_intp size0 = PyArray_DIM($input, 0);
-    const npy_intp size1 = PyArray_DIM($input, 1);
-    const npy_intp stride0 = PyArray_STRIDE($input, 0) / sizeof(MatrixType::value_type);
-    const npy_intp stride1 = PyArray_STRIDE($input, 1) / sizeof(MatrixType::value_type);
-    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA($input));
+    const npy_intp size0 = PyArray_DIM(cast_array($input), 0);
+    const npy_intp size1 = PyArray_DIM(cast_array($input), 1);
+    const npy_intp stride0 = PyArray_STRIDE(cast_array($input), 0) / sizeof(MatrixType::value_type);
+    const npy_intp stride1 = PyArray_STRIDE(cast_array($input), 1) / sizeof(MatrixType::value_type);
+    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA(cast_array($input)));
 
     const vctDynamicMatrixRef<MatrixType::value_type> tempContainer(size0, size1, stride0, stride1, data);
 
@@ -338,7 +335,7 @@ http://www.cisst.org/cisst/license.txt.
     // Look at the NumPy C API to see how these lines work: http://projects.scipy.org/numpy/wiki/NumPyCAPI
     int type = vctPythonType<MatrixType::value_type>();
     PyArray_Descr *descr = PyArray_DescrFromType(type);
-    $result = PyArray_NewFromDescr(&PyArray_Type, descr, 2, sizes, NULL, $1->Pointer(), NPY_CARRAY_RO, NULL);
+    $result = PyArray_NewFromDescr(&PyArray_Type, descr, 2, sizes, NULL, $1->Pointer(), NPY_ARRAY_CARRAY_RO, NULL);
 }
 
 
@@ -366,9 +363,9 @@ http://www.cisst.org/cisst/license.txt.
     typedef $1_ltype MatrixType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<MatrixType::value_type>($input)
-          && vctThrowUnlessDimension2($input)
-          && vctThrowUnlessCorrectMatrixSize($input, $1)
-          && vctThrowUnlessIsWritable($input))
+          && vctThrowUnlessDimension2(cast_array($input))
+          && vctThrowUnlessCorrectMatrixSize(cast_array($input), $1)
+          && vctThrowUnlessIsWritable(cast_array($input)))
         ) {
           return NULL;
     }
@@ -378,11 +375,11 @@ http://www.cisst.org/cisst/license.txt.
      OBJECT (NAMED `$1') TO MATCH THAT OF THE PYARRAY (NAMED `$input')
     *************************************************************************/
 
-    const npy_intp size0 = PyArray_DIM($input, 0);
-    const npy_intp size1 = PyArray_DIM($input, 1);
-    const npy_intp stride0 = PyArray_STRIDE($input, 0) / sizeof(MatrixType::value_type);
-    const npy_intp stride1 = PyArray_STRIDE($input, 1) / sizeof(MatrixType::value_type);
-    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA($input));
+    const npy_intp size0 = PyArray_DIM(cast_array($input), 0);
+    const npy_intp size1 = PyArray_DIM(cast_array($input), 1);
+    const npy_intp stride0 = PyArray_STRIDE(cast_array($input), 0) / sizeof(MatrixType::value_type);
+    const npy_intp stride1 = PyArray_STRIDE(cast_array($input), 1) / sizeof(MatrixType::value_type);
+    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1.SetRef(size0, size1, stride0, stride1, data);
 }
@@ -419,7 +416,7 @@ http://www.cisst.org/cisst/license.txt.
     const npy_intp size1 = ref.cols();
     const npy_intp stride0 = size1;
     const npy_intp stride1 = 1;
-    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA($result));
+    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA(cast_array($result)));
 
     vctDynamicMatrixRef<MatrixType::value_type> tempContainer(size0, size1, stride0, stride1, data);
 
@@ -451,8 +448,8 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype MatrixType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<MatrixType::value_type>($input)
-          && vctThrowUnlessDimension2($input)
-          && vctThrowUnlessCorrectMatrixSize($input, *($1)))
+          && vctThrowUnlessDimension2(cast_array($input))
+          && vctThrowUnlessCorrectMatrixSize(cast_array($input), *($1)))
         ) {
           return NULL;
     }
@@ -462,11 +459,11 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // Create the vctDynamicMatrixRef
-    const npy_intp size0 = PyArray_DIM($input, 0);
-    const npy_intp size1 = PyArray_DIM($input, 1);
-    const npy_intp stride0 = PyArray_STRIDE($input, 0) / sizeof(MatrixType::value_type);
-    const npy_intp stride1 = PyArray_STRIDE($input, 1) / sizeof(MatrixType::value_type);
-    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA($input));
+    const npy_intp size0 = PyArray_DIM(cast_array($input), 0);
+    const npy_intp size1 = PyArray_DIM(cast_array($input), 1);
+    const npy_intp stride0 = PyArray_STRIDE(cast_array($input), 0) / sizeof(MatrixType::value_type);
+    const npy_intp stride1 = PyArray_STRIDE(cast_array($input), 1) / sizeof(MatrixType::value_type);
+    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1 = new MatrixType(size0, size1, stride0, stride1, data);
 }
@@ -514,8 +511,8 @@ http://www.cisst.org/cisst/license.txt.
     typedef $1_ltype MatrixType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<MatrixType::value_type>($input)
-          && vctThrowUnlessDimension2($input)
-          && vctThrowUnlessCorrectMatrixSize($input, $1))
+          && vctThrowUnlessDimension2(cast_array($input))
+          && vctThrowUnlessCorrectMatrixSize(cast_array($input), $1))
         ) {
           return NULL;
     }
@@ -526,11 +523,11 @@ http://www.cisst.org/cisst/license.txt.
      PYARRAY (NAMED `$input')
     *****************************************************************************/
 
-    const npy_intp size0 = PyArray_DIM($input, 0);
-    const npy_intp size1 = PyArray_DIM($input, 1);
-    const npy_intp stride0 = PyArray_STRIDE($input, 0) / sizeof(MatrixType::value_type);
-    const npy_intp stride1 = PyArray_STRIDE($input, 1) / sizeof(MatrixType::value_type);
-    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA($input));
+    const npy_intp size0 = PyArray_DIM(cast_array($input), 0);
+    const npy_intp size1 = PyArray_DIM(cast_array($input), 1);
+    const npy_intp stride0 = PyArray_STRIDE(cast_array($input), 0) / sizeof(MatrixType::value_type);
+    const npy_intp stride1 = PyArray_STRIDE(cast_array($input), 1) / sizeof(MatrixType::value_type);
+    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1.SetRef(size0, size1, stride0, stride1, data);
 }
@@ -559,19 +556,19 @@ http://www.cisst.org/cisst/license.txt.
     // Look at the NumPy C API to see how these lines work: http://projects.scipy.org/numpy/wiki/NumPyCAPI
     int type = vctPythonType<MatrixType::value_type>();
     PyArray_Descr *descr = PyArray_DescrFromType(type);
-    $result = PyArray_NewFromDescr(&PyArray_Type, descr,  2, sizes, NULL, NULL, NPY_CARRAY, NULL);
-    PyArray_FLAGS($result) &= ~NPY_WRITEABLE;
+    $result = PyArray_NewFromDescr(&PyArray_Type, descr,  2, sizes, NULL, NULL, NPY_ARRAY_CARRAY, NULL);
+    PyArray_CLEARFLAGS(cast_array($result), NPY_ARRAY_WRITEABLE);
 
     /*****************************************************************************
      COPY THE DATA FROM THE vctDynamicConstMatrixRef TO THE PYARRAY
     *****************************************************************************/
 
     // Create a temporary vctDynamicMatrixRef container
-    const npy_intp size0 = PyArray_DIM($result, 0);
-    const npy_intp size1 = PyArray_DIM($result, 1);
-    const npy_intp stride0 = PyArray_STRIDE($result, 0) / sizeof(MatrixType::value_type);
-    const npy_intp stride1 = PyArray_STRIDE($result, 1) / sizeof(MatrixType::value_type);
-    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA($result));
+    const npy_intp size0 = PyArray_DIM(cast_array($result), 0);
+    const npy_intp size1 = PyArray_DIM(cast_array($result), 1);
+    const npy_intp stride0 = PyArray_STRIDE(cast_array($result), 0) / sizeof(MatrixType::value_type);
+    const npy_intp stride1 = PyArray_STRIDE(cast_array($result), 1) / sizeof(MatrixType::value_type);
+    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA(cast_array($result)));
 
     vctDynamicMatrixRef<MatrixType::value_type> tempContainer(size0, size1, stride0, stride1, data);
 
@@ -603,8 +600,8 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype MatrixType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<MatrixType::value_type>($input)
-          && vctThrowUnlessDimension2($input)
-          && vctThrowUnlessCorrectMatrixSize($input, *($1)))
+          && vctThrowUnlessDimension2(cast_array($input))
+          && vctThrowUnlessCorrectMatrixSize(cast_array($input), *($1)))
         ) {
           return NULL;
     }
@@ -614,11 +611,11 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // Create the vctDynamicConstMatrixRef
-    const npy_intp size0 = PyArray_DIM($input, 0);
-    const npy_intp size1 = PyArray_DIM($input, 1);
-    const npy_intp stride0 = PyArray_STRIDE($input, 0) / sizeof(MatrixType::value_type);
-    const npy_intp stride1 = PyArray_STRIDE($input, 1) / sizeof(MatrixType::value_type);
-    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA($input));
+    const npy_intp size0 = PyArray_DIM(cast_array($input), 0);
+    const npy_intp size1 = PyArray_DIM(cast_array($input), 1);
+    const npy_intp stride0 = PyArray_STRIDE(cast_array($input), 0) / sizeof(MatrixType::value_type);
+    const npy_intp stride1 = PyArray_STRIDE(cast_array($input), 1) / sizeof(MatrixType::value_type);
+    const MatrixType::pointer data = reinterpret_cast<MatrixType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1 = new MatrixType(size0, size1, stride0, stride1, data);
 }
@@ -651,7 +648,7 @@ http://www.cisst.org/cisst/license.txt.
         PyErr_Clear();
     } else {
         // we should test the dimension as well if we overload for vector and matrix
-        if (PyArray_NDIM($input) != 2) {
+        if (PyArray_NDIM(cast_array($input)) != 2) {
             $1 = 0;
             PyErr_Clear();
         } else {

--- a/cisstVector/vctDynamicNArrayTypemaps.i
+++ b/cisstVector/vctDynamicNArrayTypemaps.i
@@ -2,13 +2,10 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-  $Id$
-
   Author(s):  Daniel Li, Anton Deguet
   Created on: 2009-05-20
 
-  (C) Copyright 2009-2013 Johns Hopkins University (JHU), All Rights
-  Reserved.
+  (C) Copyright 2009-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -62,7 +59,7 @@ http://www.cisst.org/cisst/license.txt.
     typedef $1_ltype NArrayType;
     if (!( vctThrowUnlessIsPyArray($input)
            && vctThrowUnlessIsSameTypeArray<NArrayType::value_type>($input)
-           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>($input)
+           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>(cast_array($input))
            )
         ) {
           return NULL;
@@ -75,20 +72,20 @@ http://www.cisst.org/cisst/license.txt.
     // Create a temporary vctDynamicNArrayRef container
 
     // sizes
-    npy_intp *_sizes = PyArray_DIMS($input);
+    npy_intp *_sizes = PyArray_DIMS(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _sizesRef(_sizes);
     vctFixedSizeVector<vct::size_type, NArrayType::DIMENSION> sizes;
     sizes.Assign(_sizesRef);
 
     // strides
-    npy_intp *_strides = PyArray_STRIDES($input);
+    npy_intp *_strides = PyArray_STRIDES(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _stridesRef(_strides);
     vctFixedSizeVector<vct::stride_type, NArrayType::DIMENSION> strides;
     strides.Assign(_stridesRef);
     strides.Divide(sizeof(NArrayType::value_type));
 
     // data pointer
-    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA($input));
+    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA(cast_array($input)));
 
     const vctDynamicNArrayRef<NArrayType::value_type, NArrayType::DIMENSION> tempContainer(data, sizes, strides);
 
@@ -130,7 +127,7 @@ http://www.cisst.org/cisst/license.txt.
     // Create a temporary vctDynamicNArrayRef container
     // `sizes' defined above, don't need to redefine it
     vctFixedSizeVector<vct::stride_type, NArrayType::DIMENSION> strides($1.strides());
-    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA($result));
+    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA(cast_array($result)));
 
     vctDynamicNArrayRef<NArrayType::value_type, NArrayType::DIMENSION> tempContainer(data, sizes, strides);
 
@@ -162,9 +159,9 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype NArrayType;
     if (!( vctThrowUnlessIsPyArray($input)
            && vctThrowUnlessIsSameTypeArray<NArrayType::value_type>($input)
-           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>($input)
-           && vctThrowUnlessIsWritable($input)
-           && vctThrowUnlessOwnsData($input)
+           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>(cast_array($input))
+           && vctThrowUnlessIsWritable(cast_array($input))
+           && vctThrowUnlessOwnsData(cast_array($input))
            && vctThrowUnlessNotReferenced($input))
         ) {
           return NULL;
@@ -177,20 +174,20 @@ http://www.cisst.org/cisst/license.txt.
     // Create a temporary vctDynamicNArrayRef container
 
     // sizes
-    npy_intp *_sizes = PyArray_DIMS($input);
+    npy_intp *_sizes = PyArray_DIMS(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _sizesRef(_sizes);
     vctFixedSizeVector<vct::size_type, NArrayType::DIMENSION> sizes;
     sizes.Assign(_sizesRef);
 
     // strides
-    npy_intp *_strides = PyArray_STRIDES($input);
+    npy_intp *_strides = PyArray_STRIDES(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _stridesRef(_strides);
     vctFixedSizeVector<vct::stride_type, NArrayType::DIMENSION> strides;
     strides.Assign(_stridesRef);
     strides.Divide(sizeof(NArrayType::value_type));
 
     // data pointer
-    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA($input));
+    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA(cast_array($input)));
 
     const vctDynamicNArrayRef<NArrayType::value_type, NArrayType::DIMENSION> tempContainer(data, sizes, strides);
 
@@ -215,7 +212,7 @@ http://www.cisst.org/cisst/license.txt.
 
     typedef $*1_ltype NArrayType;
     // input sizes
-    npy_intp *_input_sizes = PyArray_DIMS($input);
+    npy_intp *_input_sizes = PyArray_DIMS(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _input_sizesRef(_input_sizes);
     vctFixedSizeVector<vct::size_type, NArrayType::DIMENSION> input_sizes;
     input_sizes.Assign(_input_sizesRef);
@@ -242,7 +239,7 @@ http://www.cisst.org/cisst/license.txt.
         PyArray_Dims dims;
         dims.ptr = sizes;
         dims.len = sz;
-        PyArray_Resize((PyArrayObject *) $input, &dims, 0, NPY_CORDER);
+        PyArray_Resize(cast_array($input), &dims, 0, NPY_CORDER);
     }
 
     /*************************************************************************
@@ -252,20 +249,20 @@ http://www.cisst.org/cisst/license.txt.
     // Create a temporary vctDynamicNArrayRef container
 
     // sizes
-    npy_intp *_sizes = PyArray_DIMS($input);
+    npy_intp *_sizes = PyArray_DIMS(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _sizesRef(_sizes);
     vctFixedSizeVector<vct::size_type, NArrayType::DIMENSION> sizes;
     sizes.Assign(_sizesRef);
 
     // strides
-    npy_intp *_strides = PyArray_STRIDES($input);
+    npy_intp *_strides = PyArray_STRIDES(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _stridesRef(_strides);
     vctFixedSizeVector<vct::stride_type, NArrayType::DIMENSION> strides;
     strides.Assign(_stridesRef);
     strides.Divide(sizeof(NArrayType::value_type));
 
     // data pointer
-    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA($input));
+    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA(cast_array($input)));
 
     // temporary container
     vctDynamicNArrayRef<NArrayType::value_type, NArrayType::DIMENSION> tempContainer(data, sizes, strides);
@@ -300,7 +297,7 @@ http://www.cisst.org/cisst/license.txt.
     // Look at the NumPy C API to see how these lines work: http://projects.scipy.org/numpy/wiki/NumPyCAPI
     int type = vctPythonType<NArrayType::value_type>();
     PyArray_Descr *descr = PyArray_DescrFromType(type);
-    $result = PyArray_NewFromDescr(&PyArray_Type, descr, sz, shape, NULL, $1->Pointer(), NPY_CARRAY, NULL);
+    $result = PyArray_NewFromDescr(&PyArray_Type, descr, sz, shape, NULL, $1->Pointer(), NPY_ARRAY_CARRAY, NULL);
 }
 
 
@@ -327,7 +324,7 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype NArrayType;
     if (!( vctThrowUnlessIsPyArray($input)
            && vctThrowUnlessIsSameTypeArray<NArrayType::value_type>($input)
-           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>($input)
+           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>(cast_array($input))
            )
         ) {
           return NULL;
@@ -340,20 +337,20 @@ http://www.cisst.org/cisst/license.txt.
     // Create a temporary vctDynamicNArrayRef container
 
     // sizes
-    npy_intp *_sizes = PyArray_DIMS($input);
+    npy_intp *_sizes = PyArray_DIMS(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _sizesRef(_sizes);
     vctFixedSizeVector<vct::size_type, NArrayType::DIMENSION> sizes;
     sizes.Assign(_sizesRef);
 
     // strides
-    npy_intp *_strides = PyArray_STRIDES($input);
+    npy_intp *_strides = PyArray_STRIDES(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _stridesRef(_strides);
     vctFixedSizeVector<vct::stride_type, NArrayType::DIMENSION> strides;
     strides.Assign(_stridesRef);
     strides.Divide(sizeof(NArrayType::value_type));
 
     // data pointer
-    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA($input));
+    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA(cast_array($input)));
 
     const vctDynamicNArrayRef<NArrayType::value_type, NArrayType::DIMENSION> tempContainer(data, sizes, strides);
 
@@ -399,7 +396,7 @@ http://www.cisst.org/cisst/license.txt.
     // Look at the NumPy C API to see how these lines work: http://projects.scipy.org/numpy/wiki/NumPyCAPI
     int type = vctPythonType<NArrayType::value_type>();
     PyArray_Descr *descr = PyArray_DescrFromType(type);
-    $result = PyArray_NewFromDescr(&PyArray_Type, descr, sz, shape, NULL, $1->Pointer(), NPY_CARRAY_RO, NULL);
+    $result = PyArray_NewFromDescr(&PyArray_Type, descr, sz, shape, NULL, $1->Pointer(), NPY_ARRAY_CARRAY_RO, NULL);
 }
 
 
@@ -427,8 +424,8 @@ http://www.cisst.org/cisst/license.txt.
     typedef $1_ltype NArrayType;
     if (!( vctThrowUnlessIsPyArray($input)
            && vctThrowUnlessIsSameTypeArray<NArrayType::value_type>($input)
-           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>($input)
-           && vctThrowUnlessIsWritable($input)
+           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>(cast_array($input))
+           && vctThrowUnlessIsWritable(cast_array($input))
            )
         ) {
           return NULL;
@@ -440,20 +437,20 @@ http://www.cisst.org/cisst/license.txt.
     *************************************************************************/
 
     // sizes
-    npy_intp *_sizes = PyArray_DIMS($input);
+    npy_intp *_sizes = PyArray_DIMS(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _sizesRef(_sizes);
     vctFixedSizeVector<vct::size_type, NArrayType::DIMENSION> sizes;
     sizes.Assign(_sizesRef);
 
     // strides
-    npy_intp *_strides = PyArray_STRIDES($input);
+    npy_intp *_strides = PyArray_STRIDES(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _stridesRef(_strides);
     vctFixedSizeVector<vct::stride_type, NArrayType::DIMENSION> strides;
     strides.Assign(_stridesRef);
     strides.Divide(sizeof(NArrayType::value_type));
 
     // data pointer
-    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA($input));
+    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1.SetRef(data, sizes, strides);
 }
@@ -492,7 +489,7 @@ http://www.cisst.org/cisst/license.txt.
     // Create a temporary vctDynamicNArrayRef container
     // `sizes' defined above, don't need to redefine it
     vctFixedSizeVector<vct::stride_type, NArrayType::DIMENSION> strides(ref.strides());
-    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA($result));
+    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA(cast_array($result)));
 
     vctDynamicNArrayRef<NArrayType::value_type, NArrayType::DIMENSION> tempContainer(data, sizes, strides);
 
@@ -524,7 +521,7 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype NArrayType;
     if (!( vctThrowUnlessIsPyArray($input)
            && vctThrowUnlessIsSameTypeArray<NArrayType::value_type>($input)
-           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>($input)
+           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>(cast_array($input))
            )
         ) {
           return NULL;
@@ -537,20 +534,20 @@ http://www.cisst.org/cisst/license.txt.
     // Create the vctDynamicNArrayRef
 
     // sizes
-    npy_intp *_sizes = PyArray_DIMS($input);
+    npy_intp *_sizes = PyArray_DIMS(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _sizesRef(_sizes);
     vctFixedSizeVector<vct::size_type, NArrayType::DIMENSION> sizes;
     sizes.Assign(_sizesRef);
 
     // strides
-    npy_intp *_strides = PyArray_STRIDES($input);
+    npy_intp *_strides = PyArray_STRIDES(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _stridesRef(_strides);
     vctFixedSizeVector<vct::stride_type, NArrayType::DIMENSION> strides;
     strides.Assign(_stridesRef);
     strides.Divide(sizeof(NArrayType::value_type));
 
     // data pointer
-    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA($input));
+    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1 = new NArrayType(data, sizes, strides);
 }
@@ -598,7 +595,7 @@ http://www.cisst.org/cisst/license.txt.
     typedef $1_ltype NArrayType;
     if (!( vctThrowUnlessIsPyArray($input)
            && vctThrowUnlessIsSameTypeArray<NArrayType::value_type>($input)
-           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>($input)
+           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>(cast_array($input))
            )
         ) {
           return NULL;
@@ -611,20 +608,20 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // sizes
-    npy_intp *_sizes = PyArray_DIMS($input);
+    npy_intp *_sizes = PyArray_DIMS(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _sizesRef(_sizes);
     vctFixedSizeVector<vct::size_type, NArrayType::DIMENSION> sizes;
     sizes.Assign(_sizesRef);
 
     // strides
-    npy_intp *_strides = PyArray_STRIDES($input);
+    npy_intp *_strides = PyArray_STRIDES(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _stridesRef(_strides);
     vctFixedSizeVector<vct::stride_type, NArrayType::DIMENSION> strides;
     strides.Assign(_stridesRef);
     strides.Divide(sizeof(NArrayType::value_type));
 
     // data pointer
-    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA($input));
+    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1.SetRef(data, sizes, strides);
 }
@@ -656,7 +653,7 @@ http://www.cisst.org/cisst/license.txt.
 
     int type = vctPythonType<NArrayType::value_type>();
     $result = PyArray_SimpleNew(sz, shape, type);
-    PyArray_FLAGS($result) &= ~NPY_WRITEABLE;
+    PyArray_CLEARFLAGS(cast_array($result), NPY_ARRAY_WRITEABLE);
 
     /*****************************************************************************
      COPY THE DATA FROM THE vctDynamicConstNArrayRef TO THE PYARRAY
@@ -665,7 +662,7 @@ http://www.cisst.org/cisst/license.txt.
     // Create a temporary vctDynamicNArrayRef container
     // `sizes' defined above, don't need to redefine it
     vctFixedSizeVector<vct::stride_type, NArrayType::DIMENSION> strides($1.strides());
-    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA($result));
+    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA(cast_array($result)));
 
     vctDynamicNArrayRef<NArrayType::value_type, NArrayType::DIMENSION> tempContainer(data, sizes, strides);
 
@@ -697,7 +694,7 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype NArrayType;
     if (!( vctThrowUnlessIsPyArray($input)
            && vctThrowUnlessIsSameTypeArray<NArrayType::value_type>($input)
-           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>($input)
+           && vctThrowUnlessDimensionN<NArrayType::DIMENSION>(cast_array($input))
            )
         ) {
           return NULL;
@@ -710,20 +707,20 @@ http://www.cisst.org/cisst/license.txt.
     // Create the vctDynamicConstNArrayRef
 
     // sizes
-    npy_intp *_sizes = PyArray_DIMS($input);
+    npy_intp *_sizes = PyArray_DIMS(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _sizesRef(_sizes);
     vctFixedSizeVector<vct::size_type, NArrayType::DIMENSION> sizes;
     sizes.Assign(_sizesRef);
 
     // strides
-    npy_intp *_strides = PyArray_STRIDES($input);
+    npy_intp *_strides = PyArray_STRIDES(cast_array($input));
     vctFixedSizeConstVectorRef<npy_intp, NArrayType::DIMENSION, 1> _stridesRef(_strides);
     vctFixedSizeVector<vct::stride_type, NArrayType::DIMENSION> strides;
     strides.Assign(_stridesRef);
     strides.Divide(sizeof(NArrayType::value_type));
 
     // data pointer
-    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA($input));
+    const NArrayType::pointer data = reinterpret_cast<NArrayType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1 = new NArrayType(data, sizes, strides);
 }

--- a/cisstVector/vctDynamicVectorTypemaps.i
+++ b/cisstVector/vctDynamicVectorTypemaps.i
@@ -2,12 +2,10 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-  $Id$
-
   Author(s):  Daniel Li, Anton Deguet, Mitch Williams
   Created on: 2009-05-20
 
-  (C) Copyright 2009-2015 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2009-2019 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -64,8 +62,8 @@ http://www.cisst.org/cisst/license.txt.
     typedef $1_ltype VectorType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<VectorType::value_type>($input)
-          && vctThrowUnlessDimension1($input)
-          && vctThrowUnlessCorrectVectorSize($input, $1))
+          && vctThrowUnlessDimension1(cast_array($input))
+          && vctThrowUnlessCorrectVectorSize(cast_array($input), $1))
         ) {
           return NULL;
     }
@@ -75,9 +73,9 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // Create a temporary vctDynamicVectorRef container
-    const npy_intp size = PyArray_DIM($input, 0);
-    const npy_intp stride = PyArray_STRIDE($input, 0) / sizeof(VectorType::value_type);
-    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA($input));
+    const npy_intp size = PyArray_DIM(cast_array($input), 0);
+    const npy_intp stride = PyArray_STRIDE(cast_array($input), 0) / sizeof(VectorType::value_type);
+    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA(cast_array($input)));
 
     const vctDynamicVectorRef<VectorType::value_type> tempContainer(size, data, stride);
 
@@ -114,7 +112,7 @@ http://www.cisst.org/cisst/license.txt.
     // Create a temporary vctDynamicVectorRef container
     const npy_intp size = $1.size();
     const npy_intp stride = 1;
-    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA($result));
+    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA(cast_array($result)));
 
     vctDynamicVectorRef<VectorType::value_type> tempContainer(size, data, stride);
 
@@ -145,10 +143,10 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype VectorType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<VectorType::value_type>($input)
-          && vctThrowUnlessDimension1($input)
-          && vctThrowUnlessCorrectVectorSize($input, *($1))
-          && vctThrowUnlessIsWritable($input)
-          && vctThrowUnlessOwnsData($input, *($1))
+          && vctThrowUnlessDimension1(cast_array($input))
+          && vctThrowUnlessCorrectVectorSize(cast_array($input), *($1))
+          && vctThrowUnlessIsWritable(cast_array($input))
+          && vctThrowUnlessOwnsData(cast_array($input), *($1))
           && vctThrowUnlessNotReferenced($input, *($1)))
         ) {
           return NULL;
@@ -159,9 +157,9 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // Create a temporary vctDynamicVectorRef container
-    const npy_intp size = PyArray_DIM($input, 0);
-    const npy_intp stride = PyArray_STRIDE($input, 0) / sizeof(VectorType::value_type);
-    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA($input));
+    const npy_intp size = PyArray_DIM(cast_array($input), 0);
+    const npy_intp stride = PyArray_STRIDE(cast_array($input), 0) / sizeof(VectorType::value_type);
+    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA(cast_array($input)));
 
     const vctDynamicVectorRef<VectorType::value_type> tempContainer(size, data, stride);
 
@@ -185,7 +183,7 @@ http://www.cisst.org/cisst/license.txt.
     *************************************************************************/
 
     typedef $*1_ltype VectorType;
-    const VectorType::size_type input_size = PyArray_DIM($input, 0);
+    const VectorType::size_type input_size = PyArray_DIM(cast_array($input), 0);
     const VectorType::size_type output_size = $1->size();
 
     if (input_size != output_size) {
@@ -197,7 +195,7 @@ http://www.cisst.org/cisst/license.txt.
         PyArray_Dims dims;                              // create a PyArray_Dims object to hand to PyArray_Resize
         dims.ptr = sizes;
         dims.len = 1;
-        PyArray_Resize((PyArrayObject *) $input, &dims, 0, NPY_CORDER);
+        PyArray_Resize(cast_array($input), &dims, 0, NPY_CORDER);
     }
 
     /*************************************************************************
@@ -205,9 +203,9 @@ http://www.cisst.org/cisst/license.txt.
     *************************************************************************/
 
     // Create a temporary vctDynamicVectorRef container
-    const npy_intp size = PyArray_DIM($input, 0);
-    const npy_intp stride = PyArray_STRIDE($input, 0) / sizeof(VectorType::value_type);
-    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA($input));
+    const npy_intp size = PyArray_DIM(cast_array($input), 0);
+    const npy_intp stride = PyArray_STRIDE(cast_array($input), 0) / sizeof(VectorType::value_type);
+    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA(cast_array($input)));
 
     vctDynamicVectorRef<VectorType::value_type> tempContainer(size, data, stride);
 
@@ -263,8 +261,8 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype VectorType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<VectorType::value_type>($input)
-          && vctThrowUnlessDimension1($input)
-          && vctThrowUnlessCorrectVectorSize($input, *($1)))
+          && vctThrowUnlessDimension1(cast_array($input))
+          && vctThrowUnlessCorrectVectorSize(cast_array($input), *($1)))
         ) {
           return NULL;
     }
@@ -274,9 +272,9 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // Create a temporary vctDynamicVectorRef container
-    const npy_intp size = PyArray_DIM($input, 0);
-    const npy_intp stride = PyArray_STRIDE($input, 0) / sizeof(VectorType::value_type);
-    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA($input));
+    const npy_intp size = PyArray_DIM(cast_array($input), 0);
+    const npy_intp stride = PyArray_STRIDE(cast_array($input), 0) / sizeof(VectorType::value_type);
+    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA(cast_array($input)));
 
     const vctDynamicVectorRef<VectorType::value_type> tempContainer(size, data, stride);
 
@@ -320,7 +318,7 @@ http://www.cisst.org/cisst/license.txt.
     // Look at the NumPy C API to see how these lines work: http://projects.scipy.org/numpy/wiki/NumPyCAPI
     int type = vctPythonType<VectorType::value_type>();
     PyArray_Descr *descr = PyArray_DescrFromType(type);
-    $result = PyArray_NewFromDescr(&PyArray_Type, descr, 1, sizes, NULL, $1->Pointer(), NPY_CARRAY_RO, NULL);
+    $result = PyArray_NewFromDescr(&PyArray_Type, descr, 1, sizes, NULL, $1->Pointer(), NPY_ARRAY_CARRAY_RO, NULL);
 }
 
 
@@ -348,9 +346,9 @@ http://www.cisst.org/cisst/license.txt.
     typedef $1_ltype VectorType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<VectorType::value_type>($input)
-          && vctThrowUnlessDimension1($input)
-          && vctThrowUnlessCorrectVectorSize($input, $1)
-          && vctThrowUnlessIsWritable($input))
+          && vctThrowUnlessDimension1(cast_array($input))
+          && vctThrowUnlessCorrectVectorSize(cast_array($input), $1)
+          && vctThrowUnlessIsWritable(cast_array($input)))
         ) {
           return NULL;
     }
@@ -360,9 +358,9 @@ http://www.cisst.org/cisst/license.txt.
      OBJECT (NAMED `$1') TO MATCH THAT OF THE PYARRAY (NAMED `$input')
     *************************************************************************/
 
-    const npy_intp size = PyArray_DIM($input, 0);
-    const npy_intp stride = PyArray_STRIDE($input, 0) / sizeof(VectorType::value_type);
-    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA($input));
+    const npy_intp size = PyArray_DIM(cast_array($input), 0);
+    const npy_intp stride = PyArray_STRIDE(cast_array($input), 0) / sizeof(VectorType::value_type);
+    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1.SetRef(size, data, stride);
 }
@@ -397,7 +395,7 @@ http://www.cisst.org/cisst/license.txt.
     // Create a temporary vctDynamicVectorRef container
     const npy_intp size = ref.size();
     const npy_intp stride = 1;
-    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA($result));
+    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA(cast_array($result)));
 
     vctDynamicVectorRef<VectorType::value_type> tempContainer(size, data, stride);
 
@@ -429,8 +427,8 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype VectorType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<VectorType::value_type>($input)
-          && vctThrowUnlessDimension1($input)
-          && vctThrowUnlessCorrectVectorSize($input, *($1)))
+          && vctThrowUnlessDimension1(cast_array($input))
+          && vctThrowUnlessCorrectVectorSize(cast_array($input), *($1)))
         ) {
           return NULL;
     }
@@ -440,9 +438,9 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // Create the vctDynamicVectorRef
-    const npy_intp size = PyArray_DIM($input, 0);
-    const npy_intp stride = PyArray_STRIDE($input, 0) / sizeof(VectorType::value_type);
-    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA($input));
+    const npy_intp size = PyArray_DIM(cast_array($input), 0);
+    const npy_intp stride = PyArray_STRIDE(cast_array($input), 0) / sizeof(VectorType::value_type);
+    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1 = new VectorType(size, data, stride);
 }
@@ -490,8 +488,8 @@ http://www.cisst.org/cisst/license.txt.
     typedef $1_ltype VectorType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<VectorType::value_type>($input)
-          && vctThrowUnlessDimension1($input)
-          && vctThrowUnlessCorrectVectorSize($input, $1))
+          && vctThrowUnlessDimension1(cast_array($input))
+          && vctThrowUnlessCorrectVectorSize(cast_array($input), $1))
         ) {
           return NULL;
     }
@@ -502,9 +500,9 @@ http://www.cisst.org/cisst/license.txt.
      PYARRAY (NAMED `$input')
     *****************************************************************************/
 
-    const npy_intp size = PyArray_DIM($input, 0);
-    const npy_intp stride = PyArray_STRIDE($input, 0) / sizeof(VectorType::value_type);
-    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA($input));
+    const npy_intp size = PyArray_DIM(cast_array($input), 0);
+    const npy_intp stride = PyArray_STRIDE(cast_array($input), 0) / sizeof(VectorType::value_type);
+    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1.SetRef(size, data, stride);
 }
@@ -532,8 +530,8 @@ http://www.cisst.org/cisst/license.txt.
     // Look at the NumPy C API to see how these lines work: http://projects.scipy.org/numpy/wiki/NumPyCAPI
     int type = vctPythonType<VectorType::value_type>();
     PyArray_Descr *descr = PyArray_DescrFromType(type);
-    $result = PyArray_NewFromDescr(&PyArray_Type, descr,  1, sizes, NULL, NULL, NPY_CARRAY, NULL);
-    PyArray_FLAGS($result) &= ~NPY_WRITEABLE;
+    $result = PyArray_NewFromDescr(&PyArray_Type, descr,  1, sizes, NULL, NULL, NPY_ARRAY_CARRAY, NULL);
+    PyArray_CLEARFLAGS(cast_array($result), NPY_ARRAY_WRITEABLE);
 
     /*****************************************************************************
      COPY THE DATA FROM THE vctDynamicConstVectorRef TO THE PYARRAY
@@ -542,7 +540,7 @@ http://www.cisst.org/cisst/license.txt.
     // Create a temporary vctDynamicVectorRef container
     const npy_intp size = $1.size();
     const npy_intp stride = 1;
-    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA($result));
+    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA(cast_array($result)));
 
     vctDynamicVectorRef<VectorType::value_type> tempContainer(size, data, stride);
 
@@ -574,8 +572,8 @@ http://www.cisst.org/cisst/license.txt.
     typedef $*1_ltype VectorType;
     if (!(   vctThrowUnlessIsPyArray($input)
           && vctThrowUnlessIsSameTypeArray<VectorType::value_type>($input)
-          && vctThrowUnlessDimension1($input)
-          && vctThrowUnlessCorrectVectorSize($input, *($1)))
+          && vctThrowUnlessDimension1(cast_array($input))
+          && vctThrowUnlessCorrectVectorSize(cast_array($input), *($1)))
         ) {
           return NULL;
     }
@@ -585,9 +583,9 @@ http://www.cisst.org/cisst/license.txt.
     *****************************************************************************/
 
     // Create the vctDynamicConstVectorRef
-    const npy_intp size = PyArray_DIM($input, 0);
-    const npy_intp stride = PyArray_STRIDE($input, 0) / sizeof(VectorType::value_type);
-    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA($input));
+    const npy_intp size = PyArray_DIM(cast_array($input), 0);
+    const npy_intp stride = PyArray_STRIDE(cast_array($input), 0) / sizeof(VectorType::value_type);
+    const VectorType::pointer data = reinterpret_cast<VectorType::pointer>(PyArray_DATA(cast_array($input)));
 
     $1 = new VectorType(size, data, stride);
 }
@@ -622,7 +620,7 @@ http://www.cisst.org/cisst/license.txt.
         PyErr_Clear();
     } else {
         // we should test the dimension as well if we overload for vector and matrix
-        if (PyArray_NDIM($input) != 1) {
+        if (PyArray_NDIM(cast_array($input)) != 1) {
             $1 = 0;
             PyErr_Clear();
         } else {

--- a/cisstVector/vctPythonUtilities.h
+++ b/cisstVector/vctPythonUtilities.h
@@ -206,7 +206,6 @@ bool vctThrowUnlessIsSameTypeArray<unsigned long int>(PyObject * input)
 }
 
 
-#if (CISST_DATA_MODEL == CISST_ILP32) || (CISST_DATA_MODEL == CISST_LLP64)
 template <>
 bool vctThrowUnlessIsSameTypeArray<long long int>(PyObject * input)
 {
@@ -226,7 +225,6 @@ bool vctThrowUnlessIsSameTypeArray<unsigned long long int>(PyObject * input)
     }
     return true;
 }
-#endif
 
 #if CISST_SIZE_T_NATIVE
 template <>
@@ -333,19 +331,6 @@ int vctPythonType<unsigned long int>(void)
     return NPY_UINT32;
 }
 
-template <>
-int vctPythonType<long long int>(void)
-{
-    return NPY_INT64;
-}
-
-
-template <>
-int vctPythonType<unsigned long long int>(void)
-{
-    return NPY_UINT64;
-}
-
 #else
 
 template <>
@@ -362,6 +347,19 @@ int vctPythonType<unsigned long int>(void)
 }
 
 #endif
+
+template <>
+int vctPythonType<long long int>(void)
+{
+    return NPY_INT64;
+}
+
+
+template <>
+int vctPythonType<unsigned long long int>(void)
+{
+    return NPY_UINT64;
+}
 
 #if CISST_SIZE_T_NATIVE
 

--- a/cisstVector/vctPythonUtilities.h
+++ b/cisstVector/vctPythonUtilities.h
@@ -206,6 +206,7 @@ bool vctThrowUnlessIsSameTypeArray<unsigned long int>(PyObject * input)
 }
 
 
+#if CISST_LONG_LONG_NATIVE
 template <>
 bool vctThrowUnlessIsSameTypeArray<long long int>(PyObject * input)
 {
@@ -225,6 +226,7 @@ bool vctThrowUnlessIsSameTypeArray<unsigned long long int>(PyObject * input)
     }
     return true;
 }
+#endif
 
 #if CISST_SIZE_T_NATIVE
 template <>
@@ -348,6 +350,7 @@ int vctPythonType<unsigned long int>(void)
 
 #endif
 
+#if CISST_LONG_LONG_NATIVE
 template <>
 int vctPythonType<long long int>(void)
 {
@@ -360,6 +363,7 @@ int vctPythonType<unsigned long long int>(void)
 {
     return NPY_UINT64;
 }
+#endif
 
 #if CISST_SIZE_T_NATIVE
 

--- a/cmake/CheckIfDifferentTypes.cmake
+++ b/cmake/CheckIfDifferentTypes.cmake
@@ -1,0 +1,68 @@
+#
+# Author(s):  Peter Kazanzides, Anton Deguet
+# Created on: 2019
+#
+# (C) Copyright 2019 Johns Hopkins University (JHU), All Rights Reserved.
+#
+# --- begin cisst license - do not edit ---
+#
+# This software is provided "as is" under an open source license, with
+# no warranty.  The complete license can be found in license.txt and
+# http://www.cisst.org/cisst/license.txt.
+#
+# --- end cisst license ---
+
+function (check_if_different_types VARIABLE type1 type2)
+  # make sure we don't test over and over
+  if (${VARIABLE} MATCHES "^${VARIABLE}$")
+    message (STATUS "Checking to see if ${type1} and ${type2} are different types")
+    set (SOURCE "
+          // First, test overloaded functions
+          char method(${type1} p) {
+             return 't1';
+          }
+          char method(${type2} p) {
+            return 't2';
+          }
+          // Next, test template specialization
+          template <class _elementType>
+          char template_method(void) {
+            return '?';
+          }
+          template <>
+          char template_method<${type1}>(void) {
+            return 't1';
+          }
+          template <>
+          char template_method<${type2}>(void) {
+            return 't2';
+          }
+          int main(void) {}")
+
+    # Convert spaces (e.g., in "long long") to underscores for file names
+    string (REPLACE " " "_" TESTFILE "test_${type1}_and_${type2}.cpp")
+    file (WRITE
+          "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/${TESTFILE}"
+          "${SOURCE}\n")
+
+    try_compile (${VARIABLE}
+                 ${CMAKE_BINARY_DIR}
+                 "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/${TESTFILE}"
+                 OUTPUT_VARIABLE OUTPUT)
+
+    # report using message and log files
+    if (${VARIABLE})
+      message (STATUS "Checking to see if ${type1} and ${type2} are different types - yes")
+      file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+            "Determining if ${type1} and ${type2} are different types passed with "
+            "the following output:\n${OUTPUT}\n\n")
+    else (${VARIABLE})
+      message (STATUS "Checking to see if ${type1} and ${type2} are different types - no")
+      file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+            "Determining if ${type1} and ${type2} are different types passed with "
+            "the following output:\n${OUTPUT}\n\n")
+    endif (${VARIABLE})
+
+  endif (${VARIABLE} MATCHES "^${VARIABLE}$")
+
+endfunction (check_if_different_types)

--- a/cmake/CheckSizeTNativeType.cmake
+++ b/cmake/CheckSizeTNativeType.cmake
@@ -1,11 +1,8 @@
 #
-# $Id $
-#
 # Author(s):  Anton Deguet
 # Created on: 2011
 #
-# (C) Copyright 2011 Johns Hopkins University (JHU), All Rights
-# Reserved.
+# (C) Copyright 2011-2019 Johns Hopkins University (JHU), All Rights Reserved.
 #
 # --- begin cisst license - do not edit ---
 #
@@ -17,7 +14,7 @@
 
 function (check_size_t_native_type VARIABLE)
   # make sure we don't test over and over
-  if ("${VARIABLE}" MATCHES "^${VARIABLE}$")
+  if (${VARIABLE} MATCHES "^${VARIABLE}$")
     message (STATUS "Checking to see if size_t is a native type")
     set (SOURCE
          "#include <vector>
@@ -54,6 +51,6 @@ function (check_size_t_native_type VARIABLE)
             "the following output:\n${OUTPUT}\n\n")
     endif (${VARIABLE})
 
-  endif ("${VARIABLE}" MATCHES "^${VARIABLE}$")
+  endif (${VARIABLE} MATCHES "^${VARIABLE}$")
 
 endfunction (check_size_t_native_type VARIABLE)

--- a/cmake/CheckSizeTNativeType.cmake
+++ b/cmake/CheckSizeTNativeType.cmake
@@ -16,6 +16,7 @@ function (check_size_t_native_type VARIABLE)
   # make sure we don't test over and over
   if (${VARIABLE} MATCHES "^${VARIABLE}$")
     message (STATUS "Checking to see if size_t is a native type")
+    # check against int and long long int
     set (SOURCE
          "#include <vector>
           char method(unsigned int p) {
@@ -30,13 +31,37 @@ function (check_size_t_native_type VARIABLE)
           int main(void) {}")
 
     file (WRITE
-          "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/test_size_t.cpp"
+          "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/test_size_t_int.cpp"
           "${SOURCE}\n")
 
-    try_compile (${VARIABLE}
+    try_compile (RESULT_int
                  ${CMAKE_BINARY_DIR}
-                 "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/test_size_t.cpp"
-                 OUTPUT_VARIABLE OUTPUT)
+                 "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/test_size_t_int.cpp"
+                 OUTPUT_VARIABLE OUTPUT_int)
+
+    # check against long int (ubuntu 18.04 default compiler apparently uses unsigned long int for size_t)
+    set (SOURCE
+         "#include <vector>
+          char method(unsigned long int p) {
+            return 'l';
+          }
+          char method(size_t p) {
+            return 's';
+          }
+          int main(void) {}")
+
+    file (WRITE
+          "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/test_size_t_long.cpp"
+          "${SOURCE}\n")
+
+    try_compile (RESULT_long
+                 ${CMAKE_BINARY_DIR}
+                 "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/test_size_t_long.cpp"
+                 OUTPUT_VARIABLE OUTPUT_long)
+
+    set (VARIABLE RESULT_int AND RESULT_long)
+
+    set (OUTPUT "${OUTPUT_int}\n${OUTPUT_long}")
 
     # report using message and log files
     if (${VARIABLE})


### PR DESCRIPTION
1. Updated to Numpy 1.7 API (no longer use deprecated items).
2. Revised `cisst_add_test` on Windows to create BAT file to set PATH.
3. Fixed bug on Windows where Numpy wrapping did not properly consider `CISST_DATA_MODEL`.
4. Added support for Numpy arrays of `size_t` elements, when `size_t` is a native type (`CISST_SIZE_T_NATIVE` true). 
5. Added CheckIfDifferentTypes.cmake and use it to set `CISST_LONG_LONG_NATIVE`.
6. If `CISST_LONG_LONG_NATIVE` is true, support  Numpy arrays of `long long` and `unsigned long long`.
7. Handle CR (`'\r'`) in cisstDataGenerator
