### PR TITLE
Image/camera data types

### DIFF
--- a/cisstCommon/cmnDataFunctionsJSON.h
+++ b/cisstCommon/cmnDataFunctionsJSON.h
@@ -70,6 +70,11 @@ template <>
 void CISST_EXPORT cmnDataJSON<unsigned int>::DeSerializeText(DataType & data, const Json::Value & jsonValue) CISST_THROW(std::runtime_error);
 
 template <>
+void CISST_EXPORT cmnDataJSON<long int>::SerializeText(const DataType & data, Json::Value & jsonValue);
+template <>
+void CISST_EXPORT cmnDataJSON<long int>::DeSerializeText(DataType & data, const Json::Value & jsonValue) CISST_THROW(std::runtime_error);
+
+template <>
 void CISST_EXPORT cmnDataJSON<unsigned long int>::SerializeText(const DataType & data, Json::Value & jsonValue);
 template <>
 void CISST_EXPORT cmnDataJSON<unsigned long int>::DeSerializeText(DataType & data, const Json::Value & jsonValue) CISST_THROW(std::runtime_error);

--- a/cisstMultiTask/code/mtsInterfaceRequired.cpp
+++ b/cisstMultiTask/code/mtsInterfaceRequired.cpp
@@ -787,6 +787,8 @@ void mtsInterfaceRequired::GetEventList(mtsEventHandlerList & eventList)
                                                                            iterEventWrite->second,
                                                                            MTS_OPTIONAL));
     }
+
+    eventList.SetValid(true);
 }
 
 

--- a/cisstMultiTask/code/mtsMailBox.cpp
+++ b/cisstMultiTask/code/mtsMailBox.cpp
@@ -222,7 +222,9 @@ void mtsMailBox::TriggerFinishedEventIfNeeded(const std::string &commandName, mt
            if (resultPointer->Valid() != result.IsOK()) {
                CMN_LOG_RUN_WARNING << "TriggerFinishedEventIfNeeded: result valid = " << resultPointer->Valid()
                                    << ", result OK = " << result.IsOK()
-                                   << ", msg = " << mtsExecutionResult::ToString(result.Value()) << std::endl;
+                                   << ", msg = " << mtsExecutionResult::ToString(result.Value())
+                                   << ", msg type = " << resultPointer->Services()->GetName()
+                                   << ", command name = " << commandName << std::endl;
            }
            resultPointer->SetValid(result.IsOK());  // Set data valid flag based on execution result
            evt_result = finishedEvent->Execute(*resultPointer, MTS_NOT_BLOCKING);

--- a/cisstParameterTypes/code/CMakeLists.txt
+++ b/cisstParameterTypes/code/CMakeLists.txt
@@ -30,6 +30,9 @@ cisst_data_generator (cisstParameterTypes
   ../prmInputData.cdg
   ../prmKeyValue.cdg
   ../prmOperatingState.cdg
+  ../prmImageFrame.cdg
+  ../prmCameraInfo.cdg
+  ../prmDepthMap.cdg
   ../prmForwardKinematicsRequest.cdg
   ../prmForwardKinematicsResponse.cdg
   ../prmInverseKinematicsRequest.cdg

--- a/cisstParameterTypes/code/prmClassServices.cpp
+++ b/cisstParameterTypes/code/prmClassServices.cpp
@@ -99,6 +99,15 @@ CMN_IMPLEMENT_SERVICES(prmInputData);
 #include <cisstParameterTypes/prmOperatingState.h>
 CMN_IMPLEMENT_SERVICES(prmOperatingState);
 
+#include <cisstParameterTypes/prmImageFrame.h>
+CMN_IMPLEMENT_SERVICES(prmImageFrame);
+
+#include <cisstParameterTypes/prmCameraInfo.h>
+CMN_IMPLEMENT_SERVICES(prmCameraInfo);
+
+#include <cisstParameterTypes/prmDepthMap.h>
+CMN_IMPLEMENT_SERVICES(prmDepthMap);
+
 #include <cisstParameterTypes/prmForwardKinematicsRequest.h>
 CMN_IMPLEMENT_SERVICES(prmForwardKinematicsRequest);
 

--- a/cisstParameterTypes/prmCameraInfo.cdg
+++ b/cisstParameterTypes/prmCameraInfo.cdg
@@ -1,0 +1,65 @@
+// -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab:
+
+inline-header {
+#include <cisstVector/vctDynamicVectorTypes.h>
+#include <cisstVector/vctDynamicNArray.h>
+#include <cisstMultiTask/mtsGenericObject.h>
+// Always include last
+#include <cisstParameterTypes/prmExport.h>
+}
+
+class {
+    name prmCameraInfo;
+
+    attribute CISST_EXPORT;
+
+    base-class {
+        type mtsGenericObject;
+        is-data true;
+    }
+
+    member {
+        name Width;
+        type size_t;
+        default 0;
+    }
+
+    member {
+        name Height;
+        type size_t;
+        default 0;
+    }
+
+    member {
+        name DistortionParameters;
+        type vctDoubleVec;
+    }
+
+    member {
+        name Intrinsic;
+        type vct3x3;
+    }
+
+    member {
+        name Rectification;
+        type vctRot3;
+    }
+
+    member {
+        name Projection;
+        type vct3x4;
+    }
+
+    inline-header {
+    public:
+
+    private:
+        CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION, CMN_LOG_ALLOW_DEFAULT);
+    }
+}
+
+
+inline-header {
+CMN_DECLARE_SERVICES_INSTANTIATION(prmCameraInfo);
+}

--- a/cisstParameterTypes/prmDepthMap.cdg
+++ b/cisstParameterTypes/prmDepthMap.cdg
@@ -1,0 +1,60 @@
+// -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab:
+
+inline-header {
+#include <cisstVector/vctDynamicVectorTypes.h>
+#include <cisstVector/vctDynamicNArray.h>
+#include <cisstMultiTask/mtsGenericObject.h>
+// Always include last
+#include <cisstParameterTypes/prmExport.h>
+}
+
+class {
+    name prmDepthMap;
+
+    attribute CISST_EXPORT;
+
+    base-class {
+        type mtsGenericObject;
+        is-data true;
+    }
+
+    member {
+        name Width;
+        type size_t;
+        default 0;
+    }
+
+    member {
+        name Height;
+        type size_t;
+        default 0;
+    }
+
+    member {
+        name Points;
+        type vctDynamicVector<float>;
+    }
+
+    member {
+        name Color;
+        type vctDynamicVector<char>;
+    }
+
+    member {
+        name ReferenceFrame;
+        type std::string;
+    }
+
+    inline-header {
+    public:
+
+    private:
+        CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION, CMN_LOG_ALLOW_DEFAULT);
+    }
+}
+
+
+inline-header {
+CMN_DECLARE_SERVICES_INSTANTIATION(prmDepthMap);
+}

--- a/cisstParameterTypes/prmImageFrame.cdg
+++ b/cisstParameterTypes/prmImageFrame.cdg
@@ -1,0 +1,56 @@
+// -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab:
+
+inline-header {
+#include <cisstVector/vctDynamicVectorTypes.h>
+#include <cisstVector/vctDynamicNArray.h>
+#include <cisstMultiTask/mtsGenericObject.h>
+// Always include last
+#include <cisstParameterTypes/prmExport.h>
+}
+
+class {
+    name prmImageFrame;
+
+    attribute CISST_EXPORT;
+
+    base-class {
+        type mtsGenericObject;
+        is-data true;
+    }
+
+    member {
+        name Width;
+        type size_t;
+        default 0;
+    }
+
+    member {
+        name Height;
+        type size_t;
+        default 0;
+    }
+
+    member {
+        name Channels;
+        type size_t;
+        default 3;
+    }
+
+    member {
+        name Data;
+        type vctDynamicVector<char>;
+    }
+
+    inline-header {
+    public:
+
+    private:
+        CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION, CMN_LOG_ALLOW_DEFAULT);
+    }
+}
+
+
+inline-header {
+CMN_DECLARE_SERVICES_INSTANTIATION(prmImageFrame);
+}


### PR DESCRIPTION
prmImageFrame for images/frame of video stream,
prmCameraInfo for camera intrinsic/extrinsic calibration info,
prmDepthMap for dense XYZ+RGB point clouds (missing regions can be set to NaN).

Also includes minor patch to mtsInterfaceRequired to prevent some warnings.