### PR TITLE
Feature python accessors

### DIFF
--- a/cisstCommon/applications/cisstDataGenerator/cdgMember.cpp
+++ b/cisstCommon/applications/cisstDataGenerator/cdgMember.cpp
@@ -178,8 +178,19 @@ void cdgMember::GenerateHeader(std::ostream & outputStream) const
     if ((accessors == "all")
         || (accessors == "set-get")) {
         outputStream << "    /* accessors is set to: " << accessors << " */" << std::endl
+                     << "#ifndef SWIG" << std::endl
                      << "    " << depr << "void Get" << name << "(" << type << " & placeHolder) const;" << std::endl
+                     << "#endif" << std::endl
+                     << "    inline " << depr << type << " Get" << name << "(void) const {" << std::endl
+                     << "        return " << MemberName << ";" << std::endl
+                     << "    }" << std::endl
                      << "    " << depr << "void Set" << name << "(const " << type << " & newValue);" << std::endl;
+                     // << "#else" << std::endl
+                     // << "    inline " << depr << type << " Get" << name << "(void) const {" << std::endl
+                     // << "        return " << MemberName << ";" << std::endl
+                     // << "    }" << std::endl
+                     // << "#endif" << std::endl
+                     // << "    " << depr << "void Set" << name << "(const " << type << " & newValue);" << std::endl;
     }
     if ((accessors == "all")
         || (accessors == "references")) {

--- a/cisstCommon/cmnDataFunctions.h
+++ b/cisstCommon/cmnDataFunctions.h
@@ -5,7 +5,7 @@
   Author(s):  Anton Deguet
   Created on: 2011-06-27
 
-  (C) Copyright 2011-2018 Johns Hopkins University (JHU), All Rights Reserved.
+  (C) Copyright 2011-2025 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -164,6 +164,20 @@ public:
     static
     bool ScalarNumberIsFixed(const DataType & data);
 };
+
+
+template <typename _elementType>
+void cmnDataCopy(_elementType & destination, const _elementType & source)
+{
+    cmnData<_elementType>::Copy(destination, source);
+}
+
+template <typename _elementType>
+std::string cmnDataHumanReadable(const _elementType & data)
+{
+    return cmnData<_elementType>::HumanReadable(data);
+}
+
 
 /* Native types to overload:
    bool

--- a/cisstCommon/cmnStrings.h
+++ b/cisstCommon/cmnStrings.h
@@ -61,9 +61,4 @@ CISST_EXPORT void cmnStringReplaceAll(std::string & userString,
   See https://gist.github.com/rodamber/2558e25d4d8f6b9f2ffdf7bd49471340 */
 CISST_EXPORT std::string cmnStringToUnderscoreLower(const std::string & input);
 
-/*! Convert a vector of strings to a single string with commas
-  separating the strings from the vector (default). */
-CISST_EXPORT std::string cmnStringFromVectorOfStrings(const std::vector<std::string> & input,
-                                                      const std::string & separator = ", ");
-
 #endif // _cmnStrings_h

--- a/cisstMultiTask/code/mtsInterfaceProvided.cpp
+++ b/cisstMultiTask/code/mtsInterfaceProvided.cpp
@@ -1243,7 +1243,7 @@ bool mtsInterfaceProvided::AddObserver(const std::string & eventName,
         CMN_LOG_CLASS_INIT_ERROR << "AddObserver (void) for \"" << GetFullName()
                                  << "\": cannot find event named \"" << eventName
                                  << "\", the following events are available: "
-                                 << cmnStringFromVectorOfStrings(GetNamesOfEventsVoid())
+                                 << cmnDataHumanReadable(GetNamesOfEventsVoid())
                                  << std::endl;
     }
     return false;
@@ -1265,7 +1265,7 @@ bool mtsInterfaceProvided::AddObserver(const std::string & eventName,
         CMN_LOG_CLASS_INIT_ERROR << "AddObserver (write) for \"" << GetFullName()
                                  << "\": cannot find event named \"" << eventName
                                  << "\", the following events are available: "
-                                 << cmnStringFromVectorOfStrings(GetNamesOfEventsWrite())
+                                 << cmnDataHumanReadable(GetNamesOfEventsWrite())
                                  << std::endl;
     }
     return false;

--- a/cisstMultiTask/code/mtsInterfaceRequired.cpp
+++ b/cisstMultiTask/code/mtsInterfaceRequired.cpp
@@ -28,6 +28,7 @@ http://www.cisst.org/cisst/license.txt.
 
 #include <cisstCommon/cmnStrings.h>
 #include <cisstCommon/cmnSerializer.h>
+#include <cisstCommon/cmnDataFunctions.h>
 #include <cisstMultiTask/mtsInterfaceProvided.h>
 #include <cisstMultiTask/mtsParameterTypes.h>
 
@@ -465,7 +466,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsVoid())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsVoid())
                                                    << std::endl;
                     } else {
                         CMN_LOG_CLASS_INIT_WARNING << "BindCommands: failed for void command \""
@@ -473,7 +474,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsVoid())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsVoid())
                                                    << std::endl;
                     }
                 } else {
@@ -514,7 +515,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsVoidReturn())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsVoidReturn())
                                                    << std::endl;
                     } else {
                         CMN_LOG_CLASS_INIT_WARNING << "BindCommands: failed for void with return command \""
@@ -522,7 +523,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsVoidReturn())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsVoidReturn())
                                                    << std::endl;
                     }
                 } else {
@@ -563,7 +564,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsWrite())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsWrite())
                                                    << std::endl;
                     } else {
                         CMN_LOG_CLASS_INIT_WARNING << "BindCommands: failed for write command \""
@@ -571,7 +572,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsWrite())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsWrite())
                                                    << std::endl;
                     }
                 } else {
@@ -612,7 +613,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsWriteReturn())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsWriteReturn())
                                                    << std::endl;
                     } else {
                         CMN_LOG_CLASS_INIT_WARNING << "BindCommands: failed for write with return command \""
@@ -620,7 +621,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsWriteReturn())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsWriteReturn())
                                                    << std::endl;
                     }
                 } else {
@@ -661,7 +662,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsRead())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsRead())
                                                    << std::endl;
                     } else {
                         CMN_LOG_CLASS_INIT_WARNING << "BindCommands: failed for read command \""
@@ -669,7 +670,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsRead())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsRead())
                                                    << std::endl;
                     }
                 } else {
@@ -710,7 +711,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsQualifiedRead())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsQualifiedRead())
                                                    << std::endl;
                     } else {
                         CMN_LOG_CLASS_INIT_WARNING << "BindCommands: failed for qualified read command \""
@@ -718,7 +719,7 @@ bool mtsInterfaceRequired::BindCommands(const mtsInterfaceProvided * interfacePr
                                                    << this->GetFullName() << "\" to \""
                                                    << interfaceProvided->GetFullName()
                                                    << "\"), the following commands are available: "
-                                                   << cmnStringFromVectorOfStrings(interfaceProvided->GetNamesOfCommandsQualifiedRead())
+                                                   << cmnDataHumanReadable(interfaceProvided->GetNamesOfCommandsQualifiedRead())
                                                    << std::endl;
                     }
                 } else {

--- a/cisstParameterTypes/code/prmRobotState.cpp
+++ b/cisstParameterTypes/code/prmRobotState.cpp
@@ -122,7 +122,8 @@ bool prmRobotStateToStateJointMeasured(const prmRobotState & input, prmStateJoin
 {
     output.Valid() = input.Valid();
     output.Timestamp() = input.Timestamp();
-    output.Name().ForceAssign(input.JointName());
+    output.Name().resize(input.JointName().size());
+    std::copy(input.JointName().begin(), input.JointName().end(), output.Name().begin());
     output.Position().ForceAssign(input.JointPosition());
     output.Velocity().ForceAssign(input.JointVelocity());
     return true;
@@ -132,7 +133,8 @@ bool prmRobotStateToStateJointSetpoint(const prmRobotState & input, prmStateJoin
 {
     output.Valid() = input.Valid();
     output.Timestamp() = input.Timestamp();
-    output.Name().ForceAssign(input.JointName());
+    output.Name().resize(input.JointName().size());
+    std::copy(input.JointName().begin(), input.JointName().end(), output.Name().begin());
     output.Position().ForceAssign(input.JointPositionGoal());
     output.Velocity().ForceAssign(input.JointVelocityGoal());
     return true;

--- a/cisstParameterTypes/prmConfigurationJoint.cdg
+++ b/cisstParameterTypes/prmConfigurationJoint.cdg
@@ -22,7 +22,7 @@ class {
 
     member {
         name Name;
-        type vctDynamicVector<std::string>;
+        type std::vector<std::string>;
     }
 
     member {

--- a/cisstParameterTypes/prmStateJoint.cdg
+++ b/cisstParameterTypes/prmStateJoint.cdg
@@ -20,8 +20,8 @@ class {
 
     member {
         name Name;
-        type vctDynamicVector<std::string>;
-        default vctDynamicVector<std::string>();
+        type std::vector<std::string>;
+        default std::vector<std::string>();
     }
 
     member {
@@ -45,7 +45,7 @@ class {
     inline-header {
     public:
         inline void SetSize(const size_t & size) {
-            Name().SetSize(size);
+            Name().resize(size);
             Position().SetSize(size);
             Velocity().SetSize(size);
             Effort().SetSize(size);


### PR DESCRIPTION
Added void accessor (GetXYZ) returning a copy in cisstDataGenerator.  This accessor is better for Python users.  Removed `vctDynamicVector<std::string>` from cisstParameterTypes, use `std::vector` instead.