### PR TITLE
Added cisstInteractive to catkin and colcon builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ if (CISST_CATKIN_BUILT)
   set (LIBRARY_OUTPUT_PATH    "${CATKIN_DEVEL_PREFIX}/lib")
   # Options defaults
   set (CISST_cisstMesh         ON  CACHE BOOL "")
+  set (CISST_cisstInteractive  ON  CACHE BOOL "")
   set (CISST_HAS_JSON          ON  CACHE BOOL "")
   set (CISST_HAS_SWIG_PYTHON   ON  CACHE BOOL "" FORCE)
   set (CISST_BUILD_SHARED_LIBS ON  CACHE BOOL "" FORCE)

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -5,6 +5,7 @@
     "-DCISSTNETLIB_USE_LOCAL_INSTALL=ON",
     "-DCISST_HAS_CISSTNETLIB=ON",
     "-DCISST_cisstMesh=ON",
+    "-DCISST_cisstInteractive=ON",
     "-DCISST_USE_SI_UNITS=ON",
     "-DCISST_HAS_QT=ON",
     "-DCISST_HAS_JSON=ON",


### PR DESCRIPTION
Building cisstInteractive would enable dynamic loading of Python shell, for example, by adding following to JSON file:
```
    "component-manager": {
        "components":
        [
            {
                "shared-library": "cisstInteractive",
                "class-name": "ireTask",
                "constructor-arg": {
                    "Name": "IRE",
                    "Shell": "IRE_IPYTHON",
                    "Startup": ""
                }
            }
        ]
    }
```