### PR TITLE
fix: use default init, not 0

### DIFF
--- a/cisstStereoVision/svlSampleImageCustom.h
+++ b/cisstStereoVision/svlSampleImageCustom.h
@@ -342,7 +342,7 @@ public:
         else return cv::Mat();
 #else // CISST_SVL_HAS_OPENCV
         CMN_LOG_CLASS_INIT_ERROR << "Class svlSampleImageCustom: CvMatRef() called while OpenCV is disabled" << std::endl;
-        return 0;
+        return {};
 #endif // CISST_SVL_HAS_OPENCV
     }
 


### PR DESCRIPTION
Small build issue fix when building stereo vision library without OpenCV support. `cv::Mat` is defined as `std::string` but this function was returning 0. 